### PR TITLE
docs: remove the extra api-reference in URLs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -65,7 +65,6 @@ footer-links:
   linkedin: https://www.linkedin.com/company/vapi-ai
 tabs:
   api-reference:
-    slug: api-reference
     icon: terminal
     display-name: API Reference
   documentation:


### PR DESCRIPTION
Per Sahil's request on Oct 26th in Slack