### PR TITLE
fix(docs): enable polling from https://api.vapi.ai/api-extended-json

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -2,6 +2,7 @@ api:
   specs:
     - openapi: ./openapi.json
       overrides: ./openapi-overrides.yml
+      origin: https://api.vapi.ai/api-extended-json
       settings:
         title-as-schema-name: false
         coerce-enums-to-literals: false

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vapi",
-  "version": "0.45.0-rc17"
+  "version": "0.45.0-rc38"
 }


### PR DESCRIPTION
This PR upgrades the Fern CLI to the latest release candidate and sets up polling from https://api.vapi.ai/api-extended-json