### PR TITLE
Upgrade `fern.config.json` to use latest cli version.

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vapi",
-  "version": "0.45.0-rc38"
+  "version": "0.45.0-rc52"
 }


### PR DESCRIPTION
Upgrading the cli version resolves the `minLength = maxLength` issue observed in the generated docs.