### PR TITLE
fix: rename voice to get around circular generation issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+**/.definition
 **/.preview/**

--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -14,7 +14,6 @@ groups:
         api:
           settings:
             unions: v1
-        disable-examples: true
         output:
           location: pypi
           package-name: "vapi_server_sdk"
@@ -36,7 +35,6 @@ groups:
           token: ${NPM_TOKEN}
         github:
           repository: VapiAI/server-sdk-typescript
-        disable-examples: true
         config:
           namespaceExport: Vapi
           allowCustomFetcher: true

--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -14,6 +14,7 @@ groups:
         api:
           settings:
             unions: v1
+        disable-examples: true
         output:
           location: pypi
           package-name: "vapi_server_sdk"
@@ -25,7 +26,7 @@ groups:
   ts-sdk:
     generators:
       - name: fernapi/fern-typescript-node-sdk
-        version: 0.40.5
+        version: 0.42.7
         api:
           settings:
             unions: v1
@@ -35,6 +36,7 @@ groups:
           token: ${NPM_TOKEN}
         github:
           repository: VapiAI/server-sdk-typescript
+        disable-examples: true
         config:
           namespaceExport: Vapi
           allowCustomFetcher: true

--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -11,6 +11,7 @@ groups:
     generators:
       - name: fernapi/fern-python-sdk
         version: 4.3.8
+        disable-examples: true
         api:
           settings:
             unions: v1
@@ -26,6 +27,7 @@ groups:
     generators:
       - name: fernapi/fern-typescript-node-sdk
         version: 0.42.7
+        disable-examples: true
         api:
           settings:
             unions: v1

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -199,6 +199,44 @@ components:
           x-fern-type-name: FallbackAzureVoiceId
         oneOf: 
           - x-fern-type-name: FallbackAzureVoiceIdEnum
+    FallbackDeepgramVoice:
+      properties:
+        voiceId:
+          x-fern-type-name: FallbackDeepgramVoiceId
+          oneOf:
+            - x-fern-type-name: FallbackDeepgramVoiceIdEnum
+    FallbackElevenLabsVoice:
+      properties:
+        voiceId:
+          x-fern-type-name: FallbackElevenLabsVoiceId
+          oneOf:
+            - x-fern-type-name: FallbackElevenLabsVoiceIdEnum
+        provider:
+          x-fern-type: literal<"11labs">
+    FallbackOpenAIVoice:
+      properties:
+        voiceId:
+          x-fern-type-name: FallbackOpenAIVoiceId
+          oneOf:
+            - x-fern-type-name: FallbackOpenAIVoiceIdEnum
+    FallbackRimeAIVoice:
+      properties:
+        voiceId:
+          x-fern-type-name: FallbackRimeAIVoiceId
+          oneOf:
+            - x-fern-type-name: FallbackRimeAIVoiceIdEnum
+    FallbackPlayHTVoice:
+      properties:
+        voiceId:
+          x-fern-type-name: FallbackPlayHTVoiceId
+          oneOf:
+            - x-fern-type-name: FallbackPlayHTVoiceIdEnum
+    FallbackLMNTVoice:
+      properties:
+        voiceId:
+          x-fern-type-name: FallbackLMNTVoiceId
+          oneOf:
+            - x-fern-type-name: FallbackLMNTVoiceIdEnum
     AzureVoice: 
       properties: 
         voiceId: 

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -183,6 +183,8 @@ paths:
       x-fern-sdk-group-name:
         - analytics
       x-fern-sdk-method-name: get
+    get: 
+      x-fern-ignore: true
   /logs:
     get:
       x-fern-pagination: true
@@ -191,6 +193,12 @@ paths:
       x-fern-sdk-method-name: get
 components: 
   schemas:
+    FallbackAzureVoice: 
+      properties: 
+        voiceId: 
+          x-fern-type-name: FallbackAzureVoiceId
+        oneOf: 
+          - x-fern-type-name: FallbackAzureVoiceIdEnum
     AzureVoice: 
       properties: 
         voiceId: 

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -237,6 +237,12 @@ components:
           x-fern-type-name: FallbackLMNTVoiceId
           oneOf:
             - x-fern-type-name: FallbackLMNTVoiceIdEnum
+    FallbackNeetsVoice:
+      properties:
+        voiceId:
+          x-fern-type-name: FallbackNeetsVoiceId
+          oneOf:
+            - x-fern-type-name: FallbackNeetsVoiceIdEnum
     AzureVoice: 
       properties: 
         voiceId: 

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vapi",
-  "version": "0.45.1"
+  "version": "0.45.3"
 }


### PR DESCRIPTION
This PR adds a necessary override to `AzureVoice`. This sort of override is required everytime Vapi is going to add a voice that contains `oneOf` with an enum and a string. 

Root cause: When there are two `oneOfs` that are not a reference to a component schema, Fern has to make a decision about what to name each variant. In this case, it's not able to come up with a good name so we use `x-fern-type-name` to set the name for the generator. 