### PR TITLE
docs: add Langfuse integration guide

### DIFF
--- a/fern/providers/observability/langfuse.mdx
+++ b/fern/providers/observability/langfuse.mdx
@@ -1,0 +1,76 @@
+---
+title: Langfuse Integration with Vapi
+description: Integrate Vapi with Langfuse for enhanced voice AI telemetry monitoring, enabling improved performance and reliability of your AI applications.
+slug: providers/observability/langfuse
+---
+
+# Vapi Integration
+
+Vapi natively integrates with Langfuse, allowing you to send traces directly to Langfuse for enhanced telemetry monitoring. This integration enables you to gain deeper insights into your voice AI applications and improve their performance and reliability.
+
+<iframe
+        src="https://youtu.be/V4ybHNWvu90"
+        title="YouTube video player"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
+        width="100%"
+        height="400px"
+        allowfullscreen
+/>
+
+## What is Langfuse?
+
+[Langfuse](https://langfuse.com/) is an open source LLM engineering platform designed to provide better **[observability](/docs/tracing)** and **[evaluations](/docs/scores/overview)** into AI applications. It helps developers track, analyze, and visualize traces from AI interactions, enabling better performance tuning, debugging, and optimization of AI agents.
+
+## Get Started
+
+<Steps>
+<Step title="Get your Langfuse Credentials">
+
+First, you'll need your Langfuse credentials:
+
+- **Secret Key**
+- **Public Key**
+- **Host URL**
+
+You can obtain these by signing up for [Langfuse Cloud](https://cloud.langfuse.com/) or [self-hosting Langfuse](https://langfuse.com/docs/deployment/self-host).
+
+</Step>
+
+<Step title="Add Langfuse Credentials">
+
+Log in to your Vapi dashboard and navigate to the [Provider Credentials page](https://dashboard.vapi.ai/keys).
+
+Under the **Observability Providers** section, you'll find an option for **Langfuse**. Enter your Langfuse credentials:
+
+- **Secret Key**
+- **Public Key**
+- **Host URL** (US data region: `https://us.cloud.langfuse.com`, EU data region: `https://cloud.langfuse.com`)
+
+Click **Save** to update your credentials.
+
+<Frame border className="sm:w-1/2">
+![Vapi Provider Credentials](https://langfuse.com/images/docs/vapi-integration-credentials.png)
+</Frame>
+
+</Step>
+
+<Step title="See Traces in Langfuse">
+
+Once you've added your credentials, you should start seeing traces in your Langfuse dashboard for every conversation your agents have.
+
+<Frame border>
+![Example trace of Vapi conversation in Langfuse](https://langfuse.com/images/docs/vapi-integration-example-trace.png)
+</Frame>
+
+Example trace in Langfuse: https://cloud.langfuse.com/project/cloramnkj0002jz088vzn1ja4/traces/50163c14-9784-4cb9-b18e-23e924d0bb66
+
+</Step>
+
+<Step title="Evaluate and Debug your Agent">
+
+To make the most out of this integration, you can now use Langfuse's [evaluation](https://langfuse.com/docs/scores/overview) and [debugging](https://langfuse.com/docs/analytics/overview) tools to analyze and improve the performance of your voice AI agents. 
+
+</Step>
+</Steps>


### PR DESCRIPTION
This docs page shows how to enable the Langfuse integration for the observability of Vapi agents.