### PR TITLE
[Docs] Add Silent Transfer instructions to Prompting Guide

### DIFF
--- a/fern/prompting-guide.mdx
+++ b/fern/prompting-guide.mdx
@@ -101,6 +101,8 @@ Example:
 3. If the user wants to know about something, use the get_data function with the parameter 'query', which will contain the user's question to initiate the process.
 4. Guide the user through the password reset steps provided by the API....
 ```
+### Silent Transfers
+If the AI determines that the user needs to be transferred, do not send any text response back to the user. Instead, silently call the appropriate tool for transferring the call. This ensures a seamless user experience and avoids confusion.
 
 ### Include Fallback and Error Handling Mechanisms
 
@@ -166,6 +168,7 @@ Present time in a clear format (e.g. Four Thirty PM) like: 11 pm can be spelled:
 Speak dates gently using English words instead of numbers.
 Never say the word 'function' nor 'tools' nor the name of the Available functions.
 Never say ending the call.
+If you think you are about to transfer the call, do not send any text response. Simply trigger the tool silently. This is crucial for maintaining a smooth call experience.
  
 [Error Handling]
 If the customer's response is unclear, ask clarifying questions. If you encounter any issues, inform the customer politely and ask to repeat.


### PR DESCRIPTION
Added a few notes to the Prompting Guide regarding Silent Transfers, specifically:

Silent Transfers section under Explicit Tool Integration section:
If the AI determines that the user needs to be transferred, do not send any text response back to the user. Instead, silently call the appropriate tool for transferring the call. This ensures a seamless user experience and avoids confusion.

Under Response Guidelines in Prompt example:
If you think you are about to transfer the call, do not send any text response. Simply trigger the tool silently. This is crucial for maintaining a smooth call experience.

