### PR TITLE
✨🌿 upgrade version

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vapi",
-  "version": "0.45.3"
+  "version": "0.46.12"
 }


### PR DESCRIPTION
This PR upgrades the Fern version of Vapi's docs. One notable improvement is removal of extraneous defaults from datetime objects in the API Reference. 

Before:
![Screenshot 2024-12-26 at 10 31 40 AM](https://github.com/user-attachments/assets/976989a3-c872-4d54-b36c-517b6a74539d)

After:
![Screenshot 2024-12-26 at 10 30 59 AM](https://github.com/user-attachments/assets/4821c28a-aa4b-4b80-abe6-62a35a5165c2)
