### PR TITLE
(suggestion) update changelog location

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -50,9 +50,6 @@ navbar-links:
     text: Status
     href: https://status.vapi.ai/
   - type: minimal
-    text: Changelog
-    href: /changelog
-  - type: minimal
     text: Support
     href: /support
   - type: filled
@@ -75,6 +72,10 @@ tabs:
     display-name: Documentation
     icon: book
     slug: documentation
+  changelog:
+    display-name: Changelog
+    slug: changelog
+    changelog: ./changelog
 layout:
   tabs-placement: header
   searchbar-placement: header
@@ -116,7 +117,6 @@ navigation:
                 path: security-and-privacy/hipaa.mdx
               - link: SOC-2 Compliance
                 href: https://security.vapi.ai/
-          - changelog: ./changelog
           - page: Support
             path: support.mdx
           - link: Status
@@ -392,6 +392,7 @@ navigation:
             href: https://api.vapi.ai/api
           - link: OpenAPI
             href: https://api.vapi.ai/api-json
+  - tab: changelog
 
 redirects:
   - source: /customization/knowledgebase

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -76,6 +76,7 @@ tabs:
     display-name: Changelog
     slug: changelog
     changelog: ./changelog
+    icon: history
 layout:
   tabs-placement: header
   searchbar-placement: header


### PR DESCRIPTION
This PR updates the location of the Changelog. 

The purpose of the move is to: 
- Reduce the number of buttons in the right-side header navigation
- Allow the changelog display to take up the full page width
- Unify the look of all sidebar links on the Documentation tab (since the Changelog is the only one with a left-side icon)

Note: slugs remain the same so SEO will not be impacted by this change.