### PR TITLE
Adding posthog integration for analytics

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -17,6 +17,7 @@ jobs:
         id: generate-docs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
         run: |
           OUTPUT=$(fern generate --docs --preview --log-level debug 2>&1) || true
           echo "$OUTPUT"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -19,4 +19,5 @@ jobs:
       - name: Publish Docs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
         run: fern generate --docs --log-level debug

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -81,6 +81,10 @@ layout:
   tabs-placement: header
   searchbar-placement: header
   header-height: 80px
+analytics:
+  posthog:
+    api-key: ${POSTHOG_PROJECT_API_KEY}
+    endpoint: https://us.i.posthog.com
 navigation:
   - tab: documentation
     layout:


### PR DESCRIPTION
We need to track analytics events in posthog. Fern provides an inbuilt integration with posthog. https://buildwithfern.com/learn/docs/integrations/analytics/posthog
https://buildwithfern.com/learn/docs/integrations/overview

