### PR TITLE
chore: disable pydantic validation in sdk

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -22,6 +22,8 @@ groups:
         github:
           repository: VapiAI/server-sdk-python
         config:
+          pydantic_config:
+            skip_validation: true
           client_class_name: Vapi
   ts-sdk:
     generators:


### PR DESCRIPTION
Disables pydantic validation (wont throw on malformed dates).