### PR TITLE
Web SDK JWT Instructions

### DIFF
--- a/fern/snippets/sdks/web/import-web-sdk.mdx
+++ b/fern/snippets/sdks/web/import-web-sdk.mdx
@@ -4,10 +4,13 @@ Import the package:
 import Vapi from "@vapi-ai/web";
 ```
 
-Then, create a new instance of the Vapi class, passing your **Public Key** as a parameter to the constructor:
+Then, create a new instance of the Vapi class, passing one of the following as a parameter to the constructor:
+- your **Public Key**
+- a generated **JWT**
 
 ```javascript
-const vapi = new Vapi("your-public-key");
+const vapi = new Vapi("your-public-key-or-jwt");
 ```
 
 You can find your public key in the [Vapi Dashboard](https://dashboard.vapi.ai/account).
+You can generate a JWT on the backend following [JWT Authentication](/customization/jwt-authentication) instructions.


### PR DESCRIPTION
It's not clear from the current documentation that the Vapi Web SDK constructor supports a JWT as an option.

I had to go through a few back and forth with email support to figure it out. So I figured updating the doc would be nice.