### PR TITLE
feat(docs): add titles and slugs to various documentation files

### DIFF
--- a/fern/assistants/assistant-hooks.mdx
+++ b/fern/assistants/assistant-hooks.mdx
@@ -1,3 +1,8 @@
+---
+title: Assistant Hooks
+slug: assistants/assistant-hooks
+---
+
 # Assistant Hooks
 
 Assistant hooks allow you to configure actions that will be performed when specific events occur during a call. Currently, hooks support the `call.ending` event, which triggers when a call is ending.

--- a/fern/calls/call-dynamic-transfers.mdx
+++ b/fern/calls/call-dynamic-transfers.mdx
@@ -1,3 +1,7 @@
+---
+title: Dynamic Call Transfers
+slug: calls/call-dynamic-transfers
+---
 ## Introduction to Transfer Destinations
 
 Transferring calls dynamically based on context is an essential feature for handling user interactions effectively. This guide walks you through creating a custom transfer tool, linking it to your assistant, and handling transfer requests with detailed examples. Whether the destination is a phone number, SIP, or another assistant, you'll learn how to configure it seamlessly.

--- a/fern/calls/call-handling-with-vapi-and-twilio.mdx
+++ b/fern/calls/call-handling-with-vapi-and-twilio.mdx
@@ -1,3 +1,8 @@
+---
+title: Call Handling with Vapi and Twilio
+slug: calls/call-handling-with-vapi-and-twilio
+---
+
 This document explains how to handle a scenario where a user is on hold while the system attempts to connect them to a specialist. If the specialist does not pick up within X seconds or if the call hits voicemail, we take an alternate action (like playing an announcement or scheduling an appointment). This solution integrates Vapi.ai for AI-driven conversations and Twilio for call bridging.
 
 ## Problem

--- a/fern/calls/voicemail-detection.mdx
+++ b/fern/calls/voicemail-detection.mdx
@@ -1,3 +1,8 @@
+---
+title: Voicemail Detection
+slug: calls/voicemail-detection
+---
+
 Voicemail is basically a digital answering machine. When you can’t pick up, callers can leave a message so you don’t miss anything important. It’s especially handy if you’re in a meeting, driving, or just can’t get to the phone in time.
 
 ### **The Main Problem**

--- a/fern/customization/custom-llm/tool-calling-integration.mdx
+++ b/fern/customization/custom-llm/tool-calling-integration.mdx
@@ -1,3 +1,7 @@
+---
+title: Custom LLM Tool Calling Integration
+slug: customization/tool-calling-integration
+---
 ## What Is a Custom LLM and Why Use It?
 
 A **Custom LLM** is more than just a text generator—it’s a conversational assistant that can call external functions, trigger processes, and handle special logic, all while chatting with your users. Think of it as your smart helper that not only answers questions but also takes actions.

--- a/fern/customization/custom-transcriber.mdx
+++ b/fern/customization/custom-transcriber.mdx
@@ -1,3 +1,7 @@
+---
+title: Custom Transcriber
+slug: customization/custom-transcriber
+---
 ## Introduction
 
 Vapi supports several transcription providers, but sometimes you may need to use your own transcription service. This guide shows you how to integrate Deepgram as your custom transcriber. The solution streams raw stereo PCM audio (16‑bit) from Vapi via WebSocket to your server, which then forwards the audio to Deepgram. Deepgram returns real‑time partial and final transcripts that are processed (including channel detection) and sent back to Vapi.

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vapi",
-  "version": "0.57.2"
+  "version": "0.57.15"
 }

--- a/fern/info-hierarchy.mdx
+++ b/fern/info-hierarchy.mdx
@@ -51,12 +51,12 @@
 * Getting Started
 * Build
     * Assistants
-    * Workflows <-- 
+    * Workflows &lt;-- 
     * Tools
     * Knowledge Base
     * Squads
 * Test
-    * Voice Testing <-- 
+    * Voice Testing &lt;-- 
 * Deploy
     * Phone Numbers
     * Calls

--- a/fern/server-url/server-authentication.mdx
+++ b/fern/server-url/server-authentication.mdx
@@ -1,3 +1,8 @@
+---
+title: Server Authentication
+slug: server-url/server-authentication
+---
+
 # Server Authentication
 
 When configuring webhooks for your assistant, you can authenticate your server endpoints using either a secret token, custom headers, or OAuth2. This ensures that only authorized requests from Vapi are processed by your server.

--- a/fern/squads/silent-transfers.mdx
+++ b/fern/squads/silent-transfers.mdx
@@ -1,3 +1,7 @@
+---
+title: Silent Transfers
+slug: squads/silent-transfers
+---
 - **The Problem**: In traditional AI call flows, when transferring from one agent to another, announcing the transfer verbally can confuse or annoy callers and disrupt the conversation's flow.
 - **The Solution**: Silent transfers keep the call experience _uninterrupted_, so the user doesn’t know multiple assistants are involved. The conversation flows more naturally, boosting customer satisfaction.
 


### PR DESCRIPTION
`find ./fern -type f -exec sh -c 'read line < "$1"; [ "$line" != "---" ] && echo "$1"' sh {} \; | grep -v images | grep -v changelog | grep -v .yml | grep -v .css | grep -v .js | grep -v snippets` 

Above command was used to find the pages which were missing the frontmatter.