### PR TITLE
VAP-5691: add RSS Feed + slack instructions

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -465,6 +465,9 @@ navigation:
           - page: Glossary
             path: glossary.mdx
 
+          - page: RSS Feed
+            path: rss-feed.mdx
+
       - section: Legal
         collapsed: true
         contents:

--- a/fern/rss-feed.mdx
+++ b/fern/rss-feed.mdx
@@ -1,0 +1,62 @@
+---
+title: RSS Feed
+subtitle: Stay updated with the latest incidents from Vapi or third party providers
+slug: rss-feed
+---
+
+## RSS Feed
+
+Vapi provides a RSS feed for the latest incidents. You can subscribe to the RSS feed to get the latest incidents from Vapi or underlying providers using the following URL.
+
+```
+https://status.vapi.ai/feed.rss
+```
+
+
+### Slack
+
+You can subscribe to the RSS feed in any application that supports it. In this guide, we will show you how to use the Slack RSS app to subscribe to our RSS feed.
+
+#### How to subscribe
+
+1. **Install the Slack RSS App**
+   - Ensure the [Slack RSS app](https://slack.com/marketplace/A0F81R7U7) is installed in your Slack workspace.
+
+2. **Open the Desired Channel**
+   - Go to the Slack channel where you wish to receive RSS updates.
+
+3. **Subscribe to the RSS Feed**
+   - Enter the following command in the message input box:
+     ```
+     /feed subscribe https://status.vapi.ai/feed.rss
+     ```
+   - Press Enter to subscribe.
+
+4. **Confirm Subscription**
+   - The Slack RSS app will confirm your subscription, and updates will start appearing in the channel.
+
+You will now receive updates in your Slack channel whenever there is an incident.
+
+#### How to unsubscribe
+
+1. **Open the Desired Channel**
+   - Go to the Slack channel from which you want to unsubscribe.
+
+2. **List Subscribed Feeds**
+   - Enter the command:
+     ```
+     /feed list
+     ```
+   - Press Enter to view all subscribed feeds.
+
+3. **Identify the Feed ID**
+   - Note the ID of the feed you wish to unsubscribe from.
+
+4. **Remove the Feed**
+   - Enter the command:
+     ```
+     /feed remove <feed_id>
+     ```
+   - Press Enter to remove the feed from the channel.
+
+You will no longer receive updates in the specified Slack channel.


### PR DESCRIPTION
context:
enterprise clients want to get notified via slack when vapi service degraded, this guide will teach them how to subscribe for slack updates using the RSS feed