### PR TITLE
Add Klen AI integration documentation to Vapi providers

### DIFF
--- a/fern/providers/klen-ai.mdx
+++ b/fern/providers/klen-ai.mdx
@@ -35,7 +35,7 @@ Klen AI's integration with Vapi includes:
 
 Ready to transform your voice AI offerings?
 
-1. [Sign up for a Klen AI account](https://app.klen.ai/signup)
+1. [Sign up for a Klen AI account](https://klen.ai/get-started)
 2. Choose the partner plan that suits your agency's needs.
 3. Configure your white-label settings and domain.
 4. Connect your Vapi API key (or use our platform key).

--- a/fern/providers/klen-ai.mdx
+++ b/fern/providers/klen-ai.mdx
@@ -1,0 +1,50 @@
+---
+title: Klen AI Integration with Vapi
+subtitle: Klen AI is a partner-first, white-label voice AI platform that transforms your agency's voice capabilities.
+slug: providers/klen-ai
+description: Experience seamless Vapi integration with Klen AI's customizable voice platform-fully branded, secure, and built for agencies.
+---
+
+Klen AI is a cutting-edge white-label platform that leverages Vapi to empower agencies to deploy bespoke voice AI solutions without writing a single line of code. Our platform offers full customization, secure API key support, and a powerful infrastructure designed to boost your business.
+
+## Key Benefits
+
+- **White-label Voice Platform:** Build and deploy voice agents under your own brand with complete control over your domain and aesthetics.
+- **Partner-Specific API Key Support:** Integrate your personal Vapi API keys for tailored control and direct billing oversight.
+- **Managed Infrastructure:** Enjoy robust webhook integration, secure authentication, and a scalable multi-tenant architecture.
+- **Advanced Scheduling & Campaign Management:** Leverage intelligent scheduling, bi-directional calendar sync, and automated outbound campaigns.
+- **Team Collaboration:** Benefit from multi-user access, shared AI agents, and role-based permissions to streamline operations.
+
+## How It Works
+
+1. **Connect Your Vapi Account:** Easily link your Vapi API credentials through our intuitive setup.
+2. **Customize Your Experience:** Brand the platform with your logo, domain, and color scheme.
+3. **Deploy Voice Agents:** Quickly create and manage voice agents powered by Vapi, complete with secure webhooks and analytics.
+4. **Scale Without Limits:** Manage multiple client accounts effortlessly with our multi-tenant infrastructure.
+
+## Integration Details
+
+Klen AI's integration with Vapi includes:
+
+- **Secure API Connections:** All communications with Vapi are secured through partner-specific secret keys and webhook validation.
+- **Dynamic Scheduling:** Real-time appointment management with built-in calendars and third-party (Google/Outlook) sync.
+- **Outbound Campaigns:** Empower your agency with batch calling, detailed call tracking, and automated follow-ups.
+- **Custom Tools & Analytics:** Access comprehensive analytics, call logs, and reporting tools to drive strategic decisions.
+
+## Get Started
+
+Ready to transform your voice AI offerings?
+
+1. [Sign up for a Klen AI account](https://app.klen.ai/signup)
+2. Choose the partner plan that suits your agency's needs.
+3. Configure your white-label settings and domain.
+4. Connect your Vapi API key (or use our platform key).
+5. Start building and deploying custom voice agents today.
+
+## Learn More
+
+For additional guidance or support, contact us at [support@klen.ai](mailto:support@klen.ai) or visit our website at [klen.ai](https://klen.ai).
+
+---
+
+Elevate your agency's voice AI services with Klen AI-where innovative integration meets unmatched customization.


### PR DESCRIPTION
This PR adds a new provider integration page for Klen AI under `fern/providers/klen-ai.mdx`.

The documentation highlights Klen AI’s white-label voice AI platform, outlining features such as:
- Vapi API key support
- Webhook integration
- Advanced scheduling
- Outbound campaign management
- Multi-tenant/team workflows
- Voice agent customization and branding

Let me know if any tweaks are needed!