### PR TITLE
VAP-5857: add more context about dtmf tool

### DIFF
--- a/fern/tools/default-tools.mdx
+++ b/fern/tools/default-tools.mdx
@@ -86,6 +86,16 @@ This function is provided when `dtmf` is included in the assistant's list of ava
 }
 ```
 
+<Note>
+There are three methods for sending DTMF in a phone call:
+
+1. **In-band DTMF**: DTMF tones are transmitted as part of the regular audio stream. This is the simplest method, but it can suffer from quality issues if the audio stream is compressed or degraded.
+2. **Out-of-band DTMF via RFC 2833**: This method sends DTMF tones separately from the audio stream, within RTP (Real-Time Protocol) packets. It's typically more reliable than in-band DTMF, particularly for VoIP applications where the audio stream might be compressed. RFC 2833 is the standard that initially defined this method. It is now replaced by RFC 4733 but this method is still referred by RFC 2833.
+3. **Out-of-band DTMF via SIP INFO messages**: In this approach, DTMF tones are sent as separate SIP INFO messages. While this can be more reliable than in-band DTMF, it's not as widely supported as the RFC 2833 method.
+
+As of writing, Vapi's DTMF tool uses in-band DTMF. Please note that this method may not work with certain IVRs. If you are running into this issue, the recommended approach is to have your assistant say the options out loud if available. For example, when an IVR says "Press 1 or say Sales for the Sales department," prefer having the assistant say "Sales."
+</Note>
+
 #### Send Text
 
 This function is provided when `sms` is included in the assistant’s list of available tool (see configuration options [here](/api-reference/assistants/create#request.body.model.openai.tools.sms)). The assistant can use this function to send SMS messages using a configured Twilio account.

--- a/fern/tools/default-tools.mdx
+++ b/fern/tools/default-tools.mdx
@@ -62,6 +62,33 @@ This function is provided when `endCall` is included in the assistant's list of 
 }
 ```
 
+#### Send Text
+
+This function is provided when `sms` is included in the assistant's list of available tool (see configuration options [here](/api-reference/assistants/create#request.body.model.openai.tools.sms)). The assistant can use this function to send SMS messages using a configured Twilio account.
+
+```json
+{
+  "model": {
+    "provider": "openai",
+    "model": "gpt-3.5-turbo",
+    "messages": [
+      {
+        "role": "system",
+        "content": "You are an assistant. When the user asks you to send a text message, use the sms function."
+      }
+    ],
+    "tools": [
+      {
+        "type": "sms",
+        "metadata": {
+          "from": "+15551234567" 
+        }
+      }
+    ]
+  }
+}
+```
+
 #### Dial Keypad (DTMF)
 
 This function is provided when `dtmf` is included in the assistant's list of available tools (see configuration options [here](/api-reference/assistants/create#request.body.model.openai.tools.dtmf)). The assistant will be able to enter digits on the keypad.
@@ -86,42 +113,37 @@ This function is provided when `dtmf` is included in the assistant's list of ava
 }
 ```
 
-<Note>
 There are three methods for sending DTMF in a phone call:
 
-1. **In-band DTMF**: DTMF tones are transmitted as part of the regular audio stream. This is the simplest method, but it can suffer from quality issues if the audio stream is compressed or degraded.
-2. **Out-of-band DTMF via RFC 2833**: This method sends DTMF tones separately from the audio stream, within RTP (Real-Time Protocol) packets. It's typically more reliable than in-band DTMF, particularly for VoIP applications where the audio stream might be compressed. RFC 2833 is the standard that initially defined this method. It is now replaced by RFC 4733 but this method is still referred by RFC 2833.
-3. **Out-of-band DTMF via SIP INFO messages**: In this approach, DTMF tones are sent as separate SIP INFO messages. While this can be more reliable than in-band DTMF, it's not as widely supported as the RFC 2833 method.
+1. **In-band**: tones are transmitted as part of the regular audio stream. This is the simplest method, but it can suffer from quality issues if the audio stream is compressed or degraded.
+2. **Out-of-band via RFC 2833**: tones are transmitted separately from the audio stream, within RTP (Real-Time Protocol) packets. It's typically more reliable than in-band DTMF, particularly for VoIP applications where the audio stream might be compressed. RFC 2833 is the standard that initially defined this method. It is now replaced by RFC 4733 but this method is still referred by RFC 2833.
+3. **Out-of-band via SIP INFO messages**: tones are sent as separate SIP INFO messages. While this can be more reliable than in-band DTMF, it's not as widely supported as the RFC 2833 method.
 
-As of writing, Vapi's DTMF tool uses in-band DTMF. Please note that this method may not work with certain IVRs. If you are running into this issue, the recommended approach is to have your assistant say the options out loud if available. For example, when an IVR says "Press 1 or say Sales for the Sales department," prefer having the assistant say "Sales."
+<Note>
+Vapi's DTMF tool uses in-band method. Please note that this method may not work with certain IVRs. If you are running into this issue, the recommended approach is to have your assistant say the options out loud if available. For example, when an IVR says "Press 1 or say Sales for the Sales department," prefer having the assistant say "Sales."
 </Note>
 
-#### Send Text
+##### Tool Effectiveness
 
-This function is provided when `sms` is included in the assistant’s list of available tool (see configuration options [here](/api-reference/assistants/create#request.body.model.openai.tools.sms)). The assistant can use this function to send SMS messages using a configured Twilio account.
+To evaluate this tool, we set up a Vapi assistant with the DTMF tool enabled and conducted calls to a range of IVR systems, including a Twilio IVR (configured via Studio Flows) and several third-party IVRs such as pharmacies and insurance companies.
 
-```json
-{
-  "model": {
-    "provider": "openai",
-    "model": "gpt-3.5-turbo",
-    "messages": [
-      {
-        "role": "system",
-        "content": "You are an assistant. When the user asks you to send a text message, use the sms function."
-      }
-    ],
-    "tools": [
-      {
-        "type": "sms",
-        "metadata": {
-          "from": "+15551234567" 
-        }
-      }
-    ]
-  }
-}
-```
+**Testing Methodology**
+
+We called and navigated through the IVRs using three different strategies:
+
+1. **Direct Dialpad**: calling from a personal phone and dialing options using the dialpad.
+2. **Vapi DTMF Tool**: an assistant configured with the DTMF tool.
+3. **Manual DTMF Sound**: calling from a personal phone and playing DTMF tones generated by software. _(similar approach as the Vapi DTMF Tool)_
+
+**Key Findings**
+
+- The assistant successfully navigated some of the third-party IVRs.
+- The assistant encountered issues with Twilio IVRs, likely due to Twilio’s preference for RFC 2833.
+- Observed occasional delays in DTMF tone transmission, which may affect effectiveness with IVRs that have short timeouts.
+
+**Conclusion**
+
+The tool's effectiveness depends on the IVR system's configuration and DTMF capturing method. We are working to improve compatibility and reduce transmission delays for broader and more reliable support.
 
 
 <Accordion title="Custom Functions: Deprecated">


### PR DESCRIPTION
### Description
Users often ask or run into issues with navigating IVR using our DTMF tool. This PR adds a note to educate about 3 known methods for sending digits on a phone call + inform the Vapi uses in-band which may not work for all IVRs.