### PR TITLE
VAP-5660: add explicitly instructions on silent transfers

### DIFF
--- a/fern/squads/silent-transfers.mdx
+++ b/fern/squads/silent-transfers.mdx
@@ -8,9 +8,13 @@ slug: squads/silent-transfers
 If you want to allow your call flow to move seamlessly from one assistant to another _without_ the caller hearing `Please hold while we transfer you` here’s what to do:
 
 1. **Update the Destination Assistant’s First Message**
-   - Set the assistant’s `firstMessage` to an _empty string_.
-   - Make sure the `firstMessageMode` is set to `assistant-speaks-first-with-model-generated-message`.
-2. **Trigger the Transfer from the Source Assistant**
+   - Set the assistant's `firstMessage` to an _empty string_.
+   - Set the assistant's `firstMessageMode` to `assistant-speaks-first-with-model-generated-message`.
+
+2. **Update the Squad's assistant destinations messages**
+   - For every `members[*].assistantDestinations[*]`, set the `message` property to an _empty string_.
+
+3. **Trigger the Transfer from the Source Assistant**
 
    - In that assistant’s prompt, include a line instructing it to transfer to the desired assistant:
 
@@ -20,7 +24,7 @@ If you want to allow your call flow to move seamlessly from one assistant to ano
 
    - Replace `'assistantName'` with the exact name of the next assistant.
 
-3. **Direct the Destination Assistant’s Behavior**
+4. **Direct the Destination Assistant’s Behavior**
    - In that assistant’s prompt, include a line instructing it to _`Proceed directly to the Task section without any greetings or small talk.`_
    - This ensures there’s no awkward greeting or “Hello!” when the next assistant begins speaking.
 
@@ -37,6 +41,10 @@ Everything happens smoothly behind the scenes!
 Below are the key JSON examples you’ll need. These show how to structure your assistants and squads so they work together for silent transfers.
 
 ### **HP Payment Squad With SubAgent**
+
+<Warning>
+  Make sure the `members[*].assistantDestinations[*].message` properties are set to an _empty string_.
+</Warning>
 
 ```json
 {
@@ -97,6 +105,7 @@ Below are the key JSON examples you’ll need. These show how to structure your 
     "temperature": 0.3
   },
   "firstMessage": "",
+  "firstMessageMode": "assistant-speaks-first-with-model-generated-message",
   "transcriber": {
     "model": "nova-2",
     "language": "en",


### PR DESCRIPTION
Users often overlook that the members[].assistantDestinations[].message must be set to an empty string for silent transfers to work, otherwise they hear the default Transferring the call now message


https://linear.app/vapi/issue/VAP-5660/make-it-more-clear-how-to-do-silent-transfers