### PR TITLE
Update docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -679,4 +679,6 @@ redirects:
   - source: /GHL
     destination: /tools/GHL
   - source: /phone-calling/voice-mail-detection
-    destination: /phone-calling/voicemail-detection
+    destination: /calls/voicemail-detection
+  - source: /phone-calling/voicemail-detection
+    destination: /calls/voicemail-detection


### PR DESCRIPTION
https://docs.vapi.ai/phone-calling/voicemail-detection takes users to 404. correct redirect to: https://docs.vapi.ai/calls/voicemail-detection. also fixed previous broken redirect link