### PR TITLE
Remove ghl and make docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -211,8 +211,6 @@ navigation:
                 path: tools/custom-tools.mdx
               - page: MCP Tool
                 path: tools/mcp.mdx
-              - page: Make & GHL Tools
-                path: GHL.mdx
               - page: Google Calendar
                 path: tools/google-calendar.mdx
               - page: Google Sheets


### PR DESCRIPTION
- this ghl and make tools are outdated and we removed from the tools page. And we're getting customer support tickets that its misleading.