### PR TITLE
chore: upgrade go sdk and introduce preview step

### DIFF
--- a/.github/workflows/preview-sdks.yml
+++ b/.github/workflows/preview-sdks.yml
@@ -3,9 +3,9 @@ name: Preview SDKs
 on:
   pull_request:
     paths:
-      - 'fern/**'
-      - 'openapi.json'
-      - 'openapi-overrides.yml'
+      - "fern/**"
+      - "openapi.json"
+      - "openapi-overrides.yml"
 
 jobs:
   preview-typescript:
@@ -33,7 +33,6 @@ jobs:
           cd fern/apis/api/.preview/fern-typescript-node-sdk
           yarn install
           yarn build
-            
 
   preview-python:
     runs-on: ubuntu-latest
@@ -47,12 +46,12 @@ jobs:
       - name: Download Fern
         run: npm install -g fern-api
 
-      - name: Preview Python SDK 
+      - name: Preview Python SDK
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
           fern generate --api api  --group python-sdk --preview --log-level debug
-    
+
       - name: Set up python
         uses: actions/setup-python@v4
         with:
@@ -63,7 +62,36 @@ jobs:
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
 
       - name: Compile
-        run: | 
+        run: |
           cd fern/apis/api/.preview/fern-python-sdk
           poetry install          
           poetry run mypy .
+
+  preview-go:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - name: Download Fern
+        run: npm install -g fern-api
+
+      - name: Preview Go SDK
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: |
+          fern generate --api api --group go-sdk --preview --log-level debug
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
+
+      - name: Compile
+        run: |
+          cd fern/apis/api/.preview/fern-go-sdk
+          go mod tidy
+          go build ./...

--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -64,7 +64,7 @@ groups:
   go-sdk:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.37.2
+        version: 0.37.4
         disable-examples: true
         api:
           settings:


### PR DESCRIPTION
Introduce preview step to catch Go SDK errors before they merge