### PR TITLE
VAP-6768 fix ghl docs with correct inputs

### DIFF
--- a/fern/tools/go-high-level.mdx
+++ b/fern/tools/go-high-level.mdx
@@ -46,7 +46,7 @@ After connecting your GoHighLevel account, create the tools:
 2. Click the **Create Tool** button.
 3. Select **GoHighLevel** from the available options.
 4. Choose which tool(s) you want to create (e.g., Get Contact, Create Contact, Check Availability, Create Event).
-5. For each tool, provide a name.
+5. For each tool, provide a clear and descriptive name. Adding a description is optional. If you leave it blank, Vapi will automatically generate a default description that explains the tool's purpose and includes the current date, formatted using the timezone you specify in the tool's metadata.
 6. For the **Check Availability** and **Create Event** tools, ensure you provide a valid `calendarId`. You can find the `calendarId` for each of your calendars in GoHighLevel by navigating to **Settings** > **Calendars**. Each calendar listed will display its unique ID.
 
 <Note>
@@ -127,8 +127,8 @@ This tool uses the following fields to create a new contact:
 This tool uses the following fields to check for open appointment slots:
 
 - `calendarId`: The ID of the GoHighLevel calendar to check.
-- `startDateTime`: The start of the time range to check for availability (epoch time in milliseconds).
-- `endDateTime`: The end of the time range to check for availability (epoch time in milliseconds).
+- `startDate`: The start of the time range to check for availability (epoch time in milliseconds).
+- `endDate`: The end of the time range to check for availability (epoch time in milliseconds).
 - `timezone`: The timezone for the availability check (e.g., "America/New_York").
 
 ### GoHighLevel Create Event Tool
@@ -138,8 +138,8 @@ This tool uses the following fields to book an appointment:
 - `calendarId`: The ID of the GoHighLevel calendar in which to create the event.
 - `contactId`: The ID of the GoHighLevel contact to associate with the event.
 - `title`: The title or summary for the calendar event.
-- `startDateTime`: The start date and time for the event in ISO 8601 format.
-- `endDateTime`: The end date and time for the event in ISO 8601 format.
+- `startTime`: The start date and time for the event in ISO 8601 format.
+- `endTime`: The end date and time for the event in ISO 8601 format.
 
 ## Example Usage
 
@@ -153,7 +153,7 @@ Here's how the tools can be configured in your assistant's JSON setup:
     "messages": [
       {
         "role": "system",
-        "content": "You are a highly efficient scheduling assistant for appointments. Your goal is to seamlessly book appointments into a calendar. Follow this precise workflow:\\n\\n1. **Gather User Info**: Start by politely asking for the caller's full name and email address.\\n2. **Check Existing Contact**: Use the 'getGHLContact' tool to check if a contact already exists with the provided email.\\n3. **Create New Contact (if necessary)**: If no contact is found with the email, use the 'createGHLContact' tool to create a new contact. You will need their name and email for this.\\n4. **Determine Appointment Needs**: Once you have a contact ID (either from an existing or newly created contact), ask the user for their preferred date and time for the appointment, and the purpose of the appointment (e.g., 'dental checkup', 'initial consultation').\\n5. **Check Calendar Availability**: Use the 'checkGHLAvailability' tool to find open slots for the requested period. Check a broad enough range (e.g., the entire day) to offer alternatives if the exact preferred time is unavailable.\\n6. **Confirm Time with User**: Discuss the available options and confirm a suitable appointment time with the user.\\n7. **Book the Appointment**: Use the 'createGHLEvent' tool to schedule the appointment. Use the purpose of the appointment as the event title.\\n\\n**Critical Notes:**\\n- Always use 'getGHLContact' before 'createGHLContact'.\\n- You MUST have a contactId before calling 'createGHLEvent'.\\n- Always use 'checkGHLAvailability' before 'createGHLEvent'.\\n- Assume all appointments are 30 minutes long unless specified otherwise by the user.\\n- Today's date is {{now}}."
+        "content": "You are a highly efficient scheduling assistant for appointments. Your goal is to seamlessly book appointments into a calendar. Follow this precise workflow:\\n\\n1. **Gather User Info**: Start by politely asking for the caller's full name and email address.\\n2. **Check Existing Contact**: Use the 'getGHLContact' tool to check if a contact already exists with the provided email.\\n3. **Create New Contact (if necessary)**: If no contact is found with the email, use the 'createGHLContact' tool to create a new contact. You will need their name and email for this.\\n4. **Determine Appointment Needs**: Once you have a contact ID (either from an existing or newly created contact), ask the user for their preferred date and time for the appointment, and the purpose of the appointment (e.g., 'dental checkup', 'initial consultation').\\n5. **Check Calendar Availability**: Use the 'checkGHLAvailability' tool to find open slots for the requested period. Check a broad enough range (e.g., the entire day) to offer alternatives if the exact preferred time is unavailable.\\n6. **Confirm Time with User**: Discuss the available options and confirm a suitable appointment time with the user.\\n7. **Book the Appointment**: Use the 'createGHLEvent' tool to schedule the appointment. Use the purpose of the appointment as the event title.\\n\\n**Critical Notes:**\\n- Always use 'getGHLContact' before 'createGHLContact'.\\n- You MUST have a contactId before calling 'createGHLEvent'.\\n- Always use 'checkGHLAvailability' before 'createGHLEvent'.\\n- Assume all appointments are 30 minutes long unless specified otherwise by the user.\\n- Today's date is {{\"now\" | date: \"%A, %B %d, %Y, %I:%M %p\", \"America/New_York\"}}."
       }
     ],
     "tools": [
@@ -161,7 +161,7 @@ Here's how the tools can be configured in your assistant's JSON setup:
         "type": "gohighlevel.calendar.availability.check",
         "function": {
           "name": "checkGHLAvailability",
-          "description": "Use this tool to check for available appointment slots in the GoHighLevel calendar. Today's date is {{now}}."
+          "description": "Use this tool to check for available appointment slots in the GoHighLevel calendar. Today's date is {{\"now\" | date: \"%A, %B %d, %Y, %I:%M %p\", \"America/New_York\"}}."
         },
         "metadata": {
           "calendarId": "CALENDAR_ID",
@@ -172,7 +172,7 @@ Here's how the tools can be configured in your assistant's JSON setup:
           "type": "gohighlevel.calendar.event.create",
           "function": {
               "name": "ghl_create_event",
-              "description": "Use this tool to create a new appointment (event) in the GoHighLevel calendar. Today's date is {{now}}. - All appointments are 30 minutes long unless specified otherwise by the user."
+              "description": "Use this tool to create a new appointment (event) in the GoHighLevel calendar. Today's date is {{\"now\" | date: \"%A, %B %d, %Y, %I:%M %p\", \"America/New_York\"}}. - All appointments are 30 minutes long unless specified otherwise by the user."
           },
           "metadata": {
               "calendarId": "CALENDAR_ID"
@@ -200,7 +200,7 @@ Here's how the tools can be configured in your assistant's JSON setup:
 ## Best Practices
 1. **Clear Instructions**: Provide clear instructions in your assistant's system message about when to use each calendar tool
 2. **Error Handling**: Include fallback responses for cases where either calendar tool fails
-3. **Time Zone Awareness**: Always specify the correct timezone for events and availability checks
+3. **Time Zone Awareness**: Always specify the correct timezone for events and availability checks. Also remember to format {{now}} with your desired timezone.
 4. **Event Details**: Ensure all required fields are properly filled when creating events
 5. **Availability Flow**: Check availability before attempting to schedule events to avoid conflicts
 6. **Contact Prerequisite for Events**: Remember that creating an event in GoHighLevel requires a `contactId`. Ensure your assistant\'s logic always fetches or creates a contact (using the `getGHLContact` and `createGHLContact` tools) before attempting to book an appointment with the `createGHLEvent` tool.


### PR DESCRIPTION
* Date inputs were not properly named
* The assistant is querying the wrong dates when {{now}} is not explicitly formatted to the proper timezone. 