### PR TITLE
fix: use correct name for ElevenLabs

### DIFF
--- a/fern/customization/custom-voices/elevenlabs.mdx
+++ b/fern/customization/custom-voices/elevenlabs.mdx
@@ -1,22 +1,22 @@
 ---
-title: Elevenlabs
-subtitle: Set up a custom Elevenlabs voice in Vapi
+title: ElevenLabs
+subtitle: Set up a custom ElevenLabs voice in Vapi
 slug: customization/custom-voices/elevenlabs
 ---
 
-This guide outlines the procedure for integrating your cloned voice with 11labs through the Vapi platform.
+This guide outlines the procedure for integrating your cloned voice with ElevenLabs through the Vapi platform.
 
 <Note>An API subscription is required for this process to work.</Note>
 
 <Steps>
-  <Step title="Obtain an 11labs API subscription">
-    Visit the [11labs pricing page](https://elevenlabs.io/pricing) and subscribe to an API plan that suits your needs.
+  <Step title="Obtain an ElevenLabs API subscription">
+    Visit the [ElevenLabs pricing page](https://elevenlabs.io/pricing) and subscribe to an API plan that suits your needs.
   </Step>
   <Step title="Retrieve your API key">
-    Go to the 'Profile + Keys' section on the 11labs website to get your API key.
+    Go to the 'Profile + Keys' section on the ElevenLabs website to get your API key.
   </Step>
   <Step title="Enter your API key in Vapi">
-    Navigate to the [Vapi Provider Key section](https://dashboard.vapi.ai/keys) and input your 11labs API key under the 11labs section.
+    Navigate to the [Vapi Provider Key section](https://dashboard.vapi.ai/keys) and input your ElevenLabs API key under the ElevenLabs section.
 
     Once you click save, your voice library will sync automatically.
   </Step>


### PR DESCRIPTION
hello Vapi team! would be great if we could use the correct name for ElevenLabs