### PR TITLE
Upgrade to the latest Fern CLI version

### DIFF
--- a/.github/workflows/preview-sdks.yml
+++ b/.github/workflows/preview-sdks.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Bootstrap poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
+          curl -sSL https://install.python-poetry.org | python - -y 
 
       - name: Compile
         run: |

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vapi",
-  "version": "0.60.21"
+  "version": "0.63.6"
 }


### PR DESCRIPTION
This PR upgrades to the latest Fern CLI Version as seen here: https://buildwithfern.com/learn/cli-reference/changelog