### PR TITLE
Fix broken URL for Web SDK

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -820,3 +820,5 @@ redirects:
     destination: /assistants/examples/voice-widget
   - source: /examples/docs-agent
     destination: /assistants/examples/docs-agent
+  - source: /sdk/web
+    destination: /quickstart/web


### PR DESCRIPTION
## Description

- Fix broken URL for Web SDK
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
