### PR TITLE
chore(docs): add union title overrides and upgrade to v3 docs parser

### DIFF
--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -746,7 +746,7 @@ components:
           name: es419
         "es-LATAM":
           name: esLATAM
-        fr-CA:
+        "fr-CA":
           name: frCA
         "hi-Latn":
           name: hiLatn
@@ -760,7 +760,7 @@ components:
           name: svSE
         "th-TH":
           name: thTH
-        zh-CN:
+        "zh-CN":
           name: zhCN
         "zh-Hans":
           name: zhHans
@@ -920,7 +920,7 @@ components:
         ";": 
           name: SEMICOLON
           description: ";"
-        ):
+        ")":
           name: PARENTHESIS
           description: ")"
         "،":

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -348,9 +348,9 @@ components:
       properties: 
         voiceId: 
           x-fern-type-name: AzureVoiceId
-          oneOf: 
-            - x-fern-type-name: AzureVoiceIdEnum
-    DeepgramVoice: 
+          oneOf:
+          - x-fern-type-name: AzureVoiceIdEnum
+    DeepgramVoice:
       title: DeepgramVoice
       properties: 
         voiceId: 
@@ -746,7 +746,7 @@ components:
           name: es419
         "es-LATAM":
           name: esLATAM
-        "fr-CA":
+        fr-CA:
           name: frCA
         "hi-Latn":
           name: hiLatn
@@ -760,7 +760,7 @@ components:
           name: svSE
         "th-TH":
           name: thTH
-        "zh-CN":
+        zh-CN:
           name: zhCN
         "zh-Hans":
           name: zhHans
@@ -920,7 +920,7 @@ components:
         ";": 
           name: SEMICOLON
           description: ";"
-        ")":  
+        ):
           name: PARENTHESIS
           description: ")"
         "،":
@@ -953,7 +953,7 @@ components:
           x-fern-type-name: CartesiaSpeedControl
 
 
-        UserMessage:
+    UserMessage:
       title: UserMessage
     SystemMessage:
       title: SystemMessage
@@ -1417,7 +1417,142 @@ components:
       title: ClientInboundMessageEndCall
     ClientInboundMessageTransfer:
       title: ClientInboundMessageTransfer
-
+    Call:
+      title: Call
+    CallBatchResponse:
+      title: CallBatchResponse
+    Chat:
+      title: Chat
+    CreateChatStreamResponse:
+      title: CreateChatStreamResponse
+    ResponseObject:
+      title: ResponseObject
+    ResponseTextDeltaEvent:
+      title: ResponseTextDeltaEvent
+    ResponseTextDoneEvent:
+      title: ResponseTextDoneEvent
+    ResponseCompletedEvent:
+      title: ResponseCompletedEvent
+    ResponseErrorEvent:
+      title: ResponseErrorEvent
+    UpdateByoPhoneNumberDTO:
+      title: UpdateByoPhoneNumberDTO
+    UpdateTwilioPhoneNumberDTO:
+      title: UpdateTwilioPhoneNumberDTO
+    UpdateVonagePhoneNumberDTO:
+      title: UpdateVonagePhoneNumberDTO
+    UpdateVapiPhoneNumberDTO:
+      title: UpdateVapiPhoneNumberDTO
+    UpdateTelnyxPhoneNumberDTO:
+      title: UpdateTelnyxPhoneNumberDTO
+    CreateGhlToolDTO:
+      title: CreateGhlToolDTO
+    CreateMakeToolDTO:
+      title: CreateMakeToolDTO
+    CreateOutputToolDTO:
+      title: CreateOutputToolDTO
+    DtmfTool:
+      title: DtmfTool
+    EndCallTool:
+      title: EndCallTool
+    FunctionTool:
+      title: FunctionTool
+    GhlTool:
+      title: GhlTool
+    MakeTool:
+      title: MakeTool
+    TransferCallTool:
+      title: TransferCallTool
+    OutputTool:
+      title: OutputTool
+    BashTool:
+      title: BashTool
+    ComputerTool:
+      title: ComputerTool
+    TextEditorTool:
+      title: TextEditorTool
+    QueryTool:
+      title: QueryTool
+    GoogleCalendarCreateEventTool:
+      title: GoogleCalendarCreateEventTool
+    GoogleSheetsRowAppendTool:
+      title: GoogleSheetsRowAppendTool
+    GoogleCalendarCheckAvailabilityTool:
+      title: GoogleCalendarCheckAvailabilityTool
+    SlackSendMessageTool:
+      title: SlackSendMessageTool
+    SmsTool:
+      title: SmsTool
+    McpTool:
+      title: McpTool
+    GoHighLevelCalendarAvailabilityTool:
+      title: GoHighLevelCalendarAvailabilityTool
+    GoHighLevelCalendarEventCreateTool:
+      title: GoHighLevelCalendarEventCreateTool
+    GoHighLevelContactCreateTool:
+      title: GoHighLevelContactCreateTool
+    GoHighLevelContactGetTool:
+      title: GoHighLevelContactGetTool
+    UpdateDtmfToolDTO:
+      title: UpdateDtmfToolDTO
+    UpdateEndCallToolDTO:
+      title: UpdateEndCallToolDTO
+    UpdateFunctionToolDTO:
+      title: UpdateFunctionToolDTO
+    UpdateGhlToolDTO:
+      title: UpdateGhlToolDTO
+    UpdateMakeToolDTO:
+      title: UpdateMakeToolDTO
+    UpdateTransferCallToolDTO:
+      title: UpdateTransferCallToolDTO
+    UpdateOutputToolDTO:
+      title: UpdateOutputToolDTO
+    UpdateBashToolDTO:
+      title: UpdateBashToolDTO
+    UpdateComputerToolDTO:
+      title: UpdateComputerToolDTO
+    UpdateTextEditorToolDTO:
+      title: UpdateTextEditorToolDTO
+    UpdateQueryToolDTO:
+      title: UpdateQueryToolDTO
+    UpdateGoogleCalendarCreateEventToolDTO:
+      title: UpdateGoogleCalendarCreateEventToolDTO
+    UpdateGoogleSheetsRowAppendToolDTO:
+      title: UpdateGoogleSheetsRowAppendToolDTO
+    UpdateGoogleCalendarCheckAvailabilityToolDTO:
+      title: UpdateGoogleCalendarCheckAvailabilityToolDTO
+    UpdateSlackSendMessageToolDTO:
+      title: UpdateSlackSendMessageToolDTO
+    UpdateSmsToolDTO:
+      title: UpdateSmsToolDTO
+    UpdateMcpToolDTO:
+      title: UpdateMcpToolDTO
+    UpdateGoHighLevelCalendarAvailabilityToolDTO:
+      title: UpdateGoHighLevelCalendarAvailabilityToolDTO
+    UpdateGoHighLevelCalendarEventCreateToolDTO:
+      title: UpdateGoHighLevelCalendarEventCreateToolDTO
+    UpdateGoHighLevelContactCreateToolDTO:
+      title: UpdateGoHighLevelContactCreateToolDTO
+    UpdateGoHighLevelContactGetToolDTO:
+      title: UpdateGoHighLevelContactGetToolDTO
+    CreateTrieveKnowledgeBaseDTO:
+      title: CreateTrieveKnowledgeBaseDTO
+    TrieveKnowledgeBase:
+      title: TrieveKnowledgeBase
+    CustomKnowledgeBase:
+      title: CustomKnowledgeBase
+    UpdateTrieveKnowledgeBaseDTO:
+      title: UpdateTrieveKnowledgeBaseDTO
+    UpdateCustomKnowledgeBaseDTO:
+      title: UpdateCustomKnowledgeBaseDTO
+    CreateTestSuiteTestVoiceDto:
+      title: CreateTestSuiteTestVoiceDto
+    CreateTestSuiteTestChatDto:
+      title: CreateTestSuiteTestChatDto
+    UpdateTestSuiteTestVoiceDto:
+      title: UpdateTestSuiteTestVoiceDto
+    UpdateTestSuiteTestChatDto:
+      title: UpdateTestSuiteTestChatDto
   securitySchemes:
     BearerAuth:
       type: http

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -258,12 +258,14 @@ components:
               "transcript[transcriptType='final']":
                 name: FinalTranscript
     ClientMessageTranscript:
+      title: ClientMessageTranscript
       properties:
         type:
           x-fern-enum:
             "transcript[transcriptType='final']":
                 name: FinalTranscript
     ServerMessageTranscript:
+      title: ServerMessageTranscript
       properties:
         type:
           x-fern-enum:
@@ -277,18 +279,21 @@ components:
               "transcript[transcriptType='final']":
                   name: FinalTranscript            
     FallbackAzureVoice: 
+      title: FallbackAzureVoice
       properties: 
         voiceId: 
           x-fern-type-name: FallbackAzureVoiceId
         oneOf: 
           - x-fern-type-name: FallbackAzureVoiceIdEnum
     FallbackDeepgramVoice:
+      title: FallbackDeepgramVoice
       properties:
         voiceId:
           x-fern-type-name: FallbackDeepgramVoiceId
           oneOf:
             - x-fern-type-name: FallbackDeepgramVoiceIdEnum
     FallbackElevenLabsVoice:
+      title: FallbackElevenLabsVoice
       properties:
         voiceId:
           x-fern-type-name: FallbackElevenLabsVoiceId
@@ -297,54 +302,63 @@ components:
         provider:
           x-fern-type: literal<"11labs">
     FallbackOpenAIVoice:
+      title: FallbackOpenAIVoice
       properties:
         voiceId:
           x-fern-type-name: FallbackOpenAIVoiceId
           oneOf:
             - x-fern-type-name: FallbackOpenAIVoiceIdEnum
     FallbackRimeAIVoice:
+      title: FallbackRimeAIVoice
       properties:
         voiceId:
           x-fern-type-name: FallbackRimeAIVoiceId
           oneOf:
             - x-fern-type-name: FallbackRimeAIVoiceIdEnum
     FallbackPlayHTVoice:
+      title: FallbackPlayHTVoice
       properties:
         voiceId:
           x-fern-type-name: FallbackPlayHTVoiceId
           oneOf:
             - x-fern-type-name: FallbackPlayHTVoiceIdEnum
     FallbackLMNTVoice:
+      title: FallbackLMNTVoice
       properties:
         voiceId:
           x-fern-type-name: FallbackLMNTVoiceId
           oneOf:
             - x-fern-type-name: FallbackLMNTVoiceIdEnum
     FallbackNeetsVoice:
+      title: FallbackNeetsVoice
       properties:
         voiceId:
           x-fern-type-name: FallbackNeetsVoiceId
           oneOf:
             - x-fern-type-name: FallbackNeetsVoiceIdEnum
     FallbackSmallestAIVoice:
+      title: FallbackSmallestAIVoice
       properties:
         voiceId:
           x-fern-type-name: FallbackSmallestAIVoiceId
           oneOf:
             - x-fern-type-name: FallbackSmallestAIVoiceIdEnum
     AzureVoice: 
+      title: AzureVoice
       properties: 
         voiceId: 
           x-fern-type-name: AzureVoiceId
           oneOf: 
             - x-fern-type-name: AzureVoiceIdEnum
     DeepgramVoice: 
+      title: DeepgramVoice
       properties: 
         voiceId: 
           x-fern-type-name: DeepgramVoiceId
           oneOf: 
             - x-fern-type-name: DeepgramVoiceIdEnum     
     ElevenLabsVoice: 
+      title: ElevenLabsVoice
       properties: 
         voiceId: 
           x-fern-type-name: ElevenLabsVoiceId
@@ -353,6 +367,7 @@ components:
         provider: 
           x-fern-type: literal<"11labs">
     SmallestAIVoice:
+      title: SmallestAIVoice
       properties:
         voiceId:
           x-fern-type-name: SmallestAIVoiceId
@@ -363,6 +378,7 @@ components:
         provider: 
           x-fern-type: literal<"11labs">
     CreateElevenLabsCredentialDTO: 
+      title: CreateElevenLabsCredentialDTO
       properties: 
         provider: 
           x-fern-type: literal<"11labs">
@@ -397,44 +413,52 @@ components:
             "#":
               name: Hash
     NeuphonicVoice: 
+      title: NeuphonicVoice
       properties: 
         voiceId: 
           x-fern-type: string      
     FallbackNeuphonicVoice: 
+      title: FallbackNeuphonicVoice
       properties: 
         voiceId: 
           x-fern-type: string
     LMNTVoice: 
+      title: LMNTVoice
       properties: 
         voiceId: 
           x-fern-type-name: LMNTVoiceId
           oneOf: 
             - x-fern-type-name: LMNTVoiceIdEnum       
-    NeetsVoice:         
+    NeetsVoice: 
+      title: NeetsVoice
       properties: 
         voiceId: 
           x-fern-type-name: NeetsVoiceId
           oneOf: 
             - x-fern-type-name: NeetsVoiceIdEnum 
     OpenAIVoice: 
+      title: OpenAIVoice
       properties: 
         voiceId: 
           x-fern-type-name: OpenAIVoiceId
           oneOf: 
             - x-fern-type-name: OpenAIVoiceIdEnum        
     RimeAIVoice: 
+      title: RimeAIVoice
       properties: 
         voiceId: 
           x-fern-type-name: RimeAIVoiceId
           oneOf: 
             - x-fern-type-name: RimeAIVoiceIdEnum 
     PlayHTVoice: 
+      title: PlayHTVoice
       properties: 
         voiceId: 
           x-fern-type-name: PlayHTVoiceId
           oneOf: 
             - x-fern-type-name: PlayHTVoiceIdEnum               
     DeepgramTranscriber: 
+      title: DeepgramTranscriber
       properties:
         model:
           $ref: "#/components/schemas/DeepgramTranscriberModel"
@@ -638,6 +662,7 @@ components:
         "base-video":
           name: baseVideo
     FallbackDeepgramTranscriber: 
+      title: FallbackDeepgramTranscriber
       properties:
         model:
           $ref: "#/components/schemas/DeepgramTranscriberModel"
@@ -841,6 +866,7 @@ components:
         "base-video":
           name: baseVideo
     TransferDestinationAssistant: 
+      title: TransferDestinationAssistant
       properties: 
         transferMode:
           $ref: "#/components/schemas/TransferMode"
@@ -925,6 +951,473 @@ components:
       properties: 
         speed: 
           x-fern-type-name: CartesiaSpeedControl
+
+
+        UserMessage:
+      title: UserMessage
+    SystemMessage:
+      title: SystemMessage
+    BotMessage:
+      title: BotMessage
+    ToolCallMessage:
+      title: ToolCallMessage
+    ToolCallResultMessage:
+      title: ToolCallResultMessage
+    FallbackAssemblyAITranscriber:
+      title: FallbackAssemblyAITranscriber
+    FallbackAzureSpeechTranscriber:
+      title: FallbackAzureSpeechTranscriber
+    FallbackCustomTranscriber:
+      title: FallbackCustomTranscriber
+    FallbackElevenLabsTranscriber:
+      title: FallbackElevenLabsTranscriber
+    FallbackGladiaTranscriber:
+      title: FallbackGladiaTranscriber
+    FallbackGoogleTranscriber:
+      title: FallbackGoogleTranscriber
+    FallbackTalkscriberTranscriber:
+      title: FallbackTalkscriberTranscriber
+    FallbackSpeechmaticsTranscriber:
+      title: FallbackSpeechmaticsTranscriber
+    FallbackOpenAITranscriber:
+      title: FallbackOpenAITranscriber
+    TextContent:
+      title: TextContent
+    ToolMessageStart:
+      title: ToolMessageStart
+    ToolMessageComplete:
+      title: ToolMessageComplete
+    ToolMessageFailed:
+      title: ToolMessageFailed
+    ToolMessageDelayed:
+      title: ToolMessageDelayed
+    CustomMessage:
+      title: CustomMessage
+    TransferDestinationNumber:
+      title: TransferDestinationNumber
+    TransferDestinationSip:
+      title: TransferDestinationSip
+    CreateApiRequestToolDTO:
+      title: CreateApiRequestToolDTO
+    CreateBashToolDTO:
+      title: CreateBashToolDTO
+    CreateComputerToolDTO:
+      title: CreateComputerToolDTO
+    CreateDtmfToolDTO:
+      title: CreateDtmfToolDTO
+    CreateEndCallToolDTO:
+      title: CreateEndCallToolDTO
+    CreateFunctionToolDTO:
+      title: CreateFunctionToolDTO
+    CreateGoHighLevelCalendarAvailabilityToolDTO:
+      title: CreateGoHighLevelCalendarAvailabilityToolDTO
+    CreateGoHighLevelCalendarEventCreateToolDTO:
+      title: CreateGoHighLevelCalendarEventCreateToolDTO
+    CreateGoHighLevelContactCreateToolDTO:
+      title: CreateGoHighLevelContactCreateToolDTO
+    CreateGoHighLevelContactGetToolDTO:
+      title: CreateGoHighLevelContactGetToolDTO
+    CreateGoogleCalendarCheckAvailabilityToolDTO:
+      title: CreateGoogleCalendarCheckAvailabilityToolDTO
+    CreateGoogleCalendarCreateEventToolDTO:
+      title: CreateGoogleCalendarCreateEventToolDTO
+    CreateGoogleSheetsRowAppendToolDTO:
+      title: CreateGoogleSheetsRowAppendToolDTO
+    CreateMcpToolDTO:
+      title: CreateMcpToolDTO
+    CreateQueryToolDTO:
+      title: CreateQueryToolDTO
+    CreateSlackSendMessageToolDTO:
+      title: CreateSlackSendMessageToolDTO
+    CreateSmsToolDTO:
+      title: CreateSmsToolDTO
+    CreateTextEditorToolDTO:
+      title: CreateTextEditorToolDTO
+    CreateTransferCallToolDTO:
+      title: CreateTransferCallToolDTO
+    CreateCustomKnowledgeBaseDTO:
+      title: CreateCustomKnowledgeBaseDTO
+    WorkflowOpenAIModel:
+      title: WorkflowOpenAIModel
+    WorkflowAnthropicModel:
+      title: WorkflowAnthropicModel
+    AssemblyAITranscriber:
+      title: AssemblyAITranscriber
+    AzureSpeechTranscriber:
+      title: AzureSpeechTranscriber
+    CustomTranscriber:
+      title: CustomTranscriber
+    ElevenLabsTranscriber:
+      title: ElevenLabsTranscriber
+    GladiaTranscriber:
+      title: GladiaTranscriber
+    GoogleTranscriber:
+      title: GoogleTranscriber
+    SpeechmaticsTranscriber:
+      title: SpeechmaticsTranscriber
+    TalkscriberTranscriber:
+      title: TalkscriberTranscriber
+    OpenAITranscriber:
+      title: OpenAITranscriber
+    CartesiaVoice:
+      title: CartesiaVoice
+    CustomVoice:
+      title: CustomVoice
+    HumeVoice:
+      title: HumeVoice
+    TavusVoice:
+      title: TavusVoice
+    VapiVoice:
+      title: VapiVoice
+    SesameVoice:
+      title: SesameVoice
+    AIEdgeCondition:
+      title: AIEdgeCondition
+    LogicEdgeCondition:
+      title: LogicEdgeCondition
+    FailedEdgeCondition:
+      title: FailedEdgeCondition
+    ConversationNode:
+      title: ConversationNode
+    ToolNode:
+      title: ToolNode
+    ExactReplacement:
+      title: ExactReplacement
+    RegexReplacement:
+      title: RegexReplacement
+    FallbackCartesiaVoice:
+      title: FallbackCartesiaVoice
+    FallbackHumeVoice:
+      title: FallbackHumeVoice
+    FallbackCustomVoice:
+      title: FallbackCustomVoice
+    FallbackVapiVoice:
+      title: FallbackVapiVoice
+    FallbackTavusVoice:
+      title: FallbackTavusVoice
+    TransferAssistantHookAction:
+      title: TransferAssistantHookAction
+    FunctionCallAssistantHookAction:
+      title: FunctionCallAssistantHookAction
+    SayAssistantHookAction:
+      title: SayAssistantHookAction
+    VapiSmartEndpointingPlan:
+      title: VapiSmartEndpointingPlan
+    LivekitSmartEndpointingPlan:
+      title: LivekitSmartEndpointingPlan
+    AssistantCustomEndpointingRule:
+      title: AssistantCustomEndpointingRule
+    CustomerCustomEndpointingRule:
+      title: CustomerCustomEndpointingRule
+    BothCustomEndpointingRule:
+      title: BothCustomEndpointingRule
+    AnthropicModel:
+      title: AnthropicModel
+    AnyscaleModel:
+      title: AnyscaleModel
+    CerebrasModel:
+      title: CerebrasModel
+    CustomLLMModel:
+      title: CustomLLMModel
+    DeepInfraModel:
+      title: DeepInfraModel
+    DeepSeekModel:
+      title: DeepSeekModel
+    GoogleModel:
+      title: GoogleModel
+    GroqModel:
+      title: GroqModel
+    InflectionAIModel:
+      title: InflectionAIModel
+    OpenAIModel:
+      title: OpenAIModel
+    OpenRouterModel:
+      title: OpenRouterModel
+    PerplexityAIModel:
+      title: PerplexityAIModel
+    TogetherAIModel:
+      title: TogetherAIModel
+    XaiModel:
+      title: XaiModel
+    GoogleVoicemailDetectionPlan:
+      title: GoogleVoicemailDetectionPlan
+    OpenAIVoicemailDetectionPlan:
+      title: OpenAIVoicemailDetectionPlan
+    TwilioVoicemailDetectionPlan:
+      title: TwilioVoicemailDetectionPlan
+    VapiVoicemailDetectionPlan:
+      title: VapiVoicemailDetectionPlan
+    TransportConfigurationTwilio:
+      title: TransportConfigurationTwilio
+    LangfuseObservabilityPlan:
+      title: LangfuseObservabilityPlan
+    CreateAnthropicCredentialDTO:
+      title: CreateAnthropicCredentialDTO
+    CreateAnyscaleCredentialDTO:
+      title: CreateAnyscaleCredentialDTO
+    CreateAssemblyAICredentialDTO:
+      title: CreateAssemblyAICredentialDTO
+    CreateAzureCredentialDTO:
+      title: CreateAzureCredentialDTO
+    CreateAzureOpenAICredentialDTO:
+      title: CreateAzureOpenAICredentialDTO
+    CreateByoSipTrunkCredentialDTO:
+      title: CreateByoSipTrunkCredentialDTO
+    CreateCartesiaCredentialDTO:
+      title: CreateCartesiaCredentialDTO
+    CreateCerebrasCredentialDTO:
+      title: CreateCerebrasCredentialDTO
+    CreateCloudflareCredentialDTO:
+      title: CreateCloudflareCredentialDTO
+    CreateCustomLLMCredentialDTO:
+      title: CreateCustomLLMCredentialDTO
+    CreateDeepgramCredentialDTO:
+      title: CreateDeepgramCredentialDTO
+    CreateDeepInfraCredentialDTO:
+      title: CreateDeepInfraCredentialDTO
+    CreateDeepSeekCredentialDTO:
+      title: CreateDeepSeekCredentialDTO
+    CreateGcpCredentialDTO:
+      title: CreateGcpCredentialDTO
+    CreateGladiaCredentialDTO:
+      title: CreateGladiaCredentialDTO
+    CreateGoHighLevelCredentialDTO:
+      title: CreateGoHighLevelCredentialDTO
+    CreateGoogleCredentialDTO:
+      title: CreateGoogleCredentialDTO
+    CreateGroqCredentialDTO:
+      title: CreateGroqCredentialDTO
+    CreateHumeCredentialDTO:
+      title: CreateHumeCredentialDTO
+    CreateInflectionAICredentialDTO:
+      title: CreateInflectionAICredentialDTO
+    CreateLangfuseCredentialDTO:
+      title: CreateLangfuseCredentialDTO
+    CreateLmntCredentialDTO:
+      title: CreateLmntCredentialDTO
+    CreateMakeCredentialDTO:
+      title: CreateMakeCredentialDTO
+    CreateMistralCredentialDTO:
+      title: CreateMistralCredentialDTO
+    CreateNeuphonicCredentialDTO:
+      title: CreateNeuphonicCredentialDTO
+    CreateOpenAICredentialDTO:
+      title: CreateOpenAICredentialDTO
+    CreateOpenRouterCredentialDTO:
+      title: CreateOpenRouterCredentialDTO
+    CreatePerplexityAICredentialDTO:
+      title: CreatePerplexityAICredentialDTO
+    CreatePlayHTCredentialDTO:
+      title: CreatePlayHTCredentialDTO
+    CreateRimeAICredentialDTO:
+      title: CreateRimeAICredentialDTO
+    CreateRunpodCredentialDTO:
+      title: CreateRunpodCredentialDTO
+    CreateS3CredentialDTO:
+      title: CreateS3CredentialDTO
+    CreateSmallestAICredentialDTO:
+      title: CreateSmallestAICredentialDTO
+    CreateSpeechmaticsCredentialDTO:
+      title: CreateSpeechmaticsCredentialDTO
+    CreateSupabaseCredentialDTO:
+      title: CreateSupabaseCredentialDTO
+    CreateTavusCredentialDTO:
+      title: CreateTavusCredentialDTO
+    CreateTogetherAICredentialDTO:
+      title: CreateTogetherAICredentialDTO
+    CreateTrieveCredentialDTO:
+      title: CreateTrieveCredentialDTO
+    CreateTwilioCredentialDTO:
+      title: CreateTwilioCredentialDTO
+    CreateVonageCredentialDTO:
+      title: CreateVonageCredentialDTO
+    CreateWebhookCredentialDTO:
+      title: CreateWebhookCredentialDTO
+    CreateXAiCredentialDTO:
+      title: CreateXAiCredentialDTO
+    CreateGoogleCalendarOAuth2ClientCredentialDTO:
+      title: CreateGoogleCalendarOAuth2ClientCredentialDTO
+    CreateGoogleCalendarOAuth2AuthorizationCredentialDTO:
+      title: CreateGoogleCalendarOAuth2AuthorizationCredentialDTO
+    CreateGoogleSheetsOAuth2AuthorizationCredentialDTO:
+      title: CreateGoogleSheetsOAuth2AuthorizationCredentialDTO
+    CreateSlackOAuth2AuthorizationCredentialDTO:
+      title: CreateSlackOAuth2AuthorizationCredentialDTO
+    CreateGoHighLevelMCPCredentialDTO:
+      title: CreateGoHighLevelMCPCredentialDTO
+    AssistantHookCallEnding:
+      title: AssistantHookCallEnding
+    AssistantHookAssistantSpeechInterrupted:
+      title: AssistantHookAssistantSpeechInterrupted
+    AssistantHookCustomerSpeechInterrupted:
+      title: AssistantHookCustomerSpeechInterrupted
+    TransferPhoneNumberHookAction:
+      title: TransferPhoneNumberHookAction
+    SayPhoneNumberHookAction:
+      title: SayPhoneNumberHookAction
+    PhoneNumberHookCallRinging:
+      title: PhoneNumberHookCallRinging
+    TransportCost:
+      title: TransportCost
+    TranscriberCost:
+      title: TranscriberCost
+    ModelCost:
+      title: ModelCost
+    VoiceCost:
+      title: VoiceCost
+    VapiCost:
+      title: VapiCost
+    VoicemailDetectionCost:
+      title: VoicemailDetectionCost
+    AnalysisCost:
+      title: AnalysisCost
+    KnowledgeBaseCost:
+      title: KnowledgeBaseCost
+    AssistantMessage:
+      title: AssistantMessage
+    ToolMessage:
+      title: ToolMessage
+    DeveloperMessage:
+      title: DeveloperMessage
+    ByoPhoneNumber:
+      title: ByoPhoneNumber
+    TwilioPhoneNumber:
+      title: TwilioPhoneNumber
+    VonagePhoneNumber:
+      title: VonagePhoneNumber
+    VapiPhoneNumber:
+      title: VapiPhoneNumber
+    TelnyxPhoneNumber:
+      title: TelnyxPhoneNumber
+    TrieveKnowledgeBaseImport:
+      title: TrieveKnowledgeBaseImport
+    TestSuiteTestScorerAI:
+      title: TestSuiteTestScorerAI
+    TestSuiteTestVoice:
+      title: TestSuiteTestVoice
+    TestSuiteTestChat:
+      title: TestSuiteTestChat
+    TestSuiteRunScorerAI:
+      title: TestSuiteRunScorerAI
+    MakeToolProviderDetails:
+      title: MakeToolProviderDetails
+    GhlToolProviderDetails:
+      title: GhlToolProviderDetails
+    FunctionToolProviderDetails:
+      title: FunctionToolProviderDetails
+    GoogleCalendarCreateEventToolProviderDetails:
+      title: GoogleCalendarCreateEventToolProviderDetails
+    GoogleSheetsRowAppendToolProviderDetails:
+      title: GoogleSheetsRowAppendToolProviderDetails
+    GoHighLevelCalendarAvailabilityToolProviderDetails:
+      title: GoHighLevelCalendarAvailabilityToolProviderDetails
+    GoHighLevelCalendarEventCreateToolProviderDetails:
+      title: GoHighLevelCalendarEventCreateToolProviderDetails
+    GoHighLevelContactCreateToolProviderDetails:
+      title: GoHighLevelContactCreateToolProviderDetails
+    GoHighLevelContactGetToolProviderDetails:
+      title: GoHighLevelContactGetToolProviderDetails
+    CreateByoPhoneNumberDTO:
+      title: CreateByoPhoneNumberDTO
+    CreateTwilioPhoneNumberDTO:
+      title: CreateTwilioPhoneNumberDTO
+    CreateVonagePhoneNumberDTO:
+      title: CreateVonagePhoneNumberDTO
+    CreateVapiPhoneNumberDTO:
+      title: CreateVapiPhoneNumberDTO
+    CreateTelnyxPhoneNumberDTO:
+      title: CreateTelnyxPhoneNumberDTO
+    FunctionToolWithToolCall:
+      title: FunctionToolWithToolCall
+    GhlToolWithToolCall:
+      title: GhlToolWithToolCall
+    MakeToolWithToolCall:
+      title: MakeToolWithToolCall
+    BashToolWithToolCall:
+      title: BashToolWithToolCall
+    ComputerToolWithToolCall:
+      title: ComputerToolWithToolCall
+    TextEditorToolWithToolCall:
+      title: TextEditorToolWithToolCall
+    GoogleCalendarCreateEventToolWithToolCall:
+      title: GoogleCalendarCreateEventToolWithToolCall
+    ClientMessageWorkflowNodeStarted:
+      title: ClientMessageWorkflowNodeStarted
+    ClientMessageConversationUpdate:
+      title: ClientMessageConversationUpdate
+    ClientMessageHang:
+      title: ClientMessageHang
+    ClientMessageMetadata:
+      title: ClientMessageMetadata
+    ClientMessageModelOutput:
+      title: ClientMessageModelOutput
+    ClientMessageSpeechUpdate:
+      title: ClientMessageSpeechUpdate
+    ClientMessageToolCalls:
+      title: ClientMessageToolCalls
+    ClientMessageToolCallsResult:
+      title: ClientMessageToolCallsResult
+    ClientMessageTransferUpdate:
+      title: ClientMessageTransferUpdate
+    ClientMessageUserInterrupted:
+      title: ClientMessageUserInterrupted
+    ClientMessageLanguageChangeDetected:
+      title: ClientMessageLanguageChangeDetected
+    ClientMessageVoiceInput:
+      title: ClientMessageVoiceInput
+    ServerMessageAssistantRequest:
+      title: ServerMessageAssistantRequest
+    ServerMessageConversationUpdate:
+      title: ServerMessageConversationUpdate
+    ServerMessageEndOfCallReport:
+      title: ServerMessageEndOfCallReport
+    ServerMessageHang:
+      title: ServerMessageHang
+    ServerMessageKnowledgeBaseRequest:
+      title: ServerMessageKnowledgeBaseRequest
+    ServerMessageModelOutput:
+      title: ServerMessageModelOutput
+    ServerMessagePhoneCallControl:
+      title: ServerMessagePhoneCallControl
+    ServerMessageSpeechUpdate:
+      title: ServerMessageSpeechUpdate
+    ServerMessageStatusUpdate:
+      title: ServerMessageStatusUpdate
+    ServerMessageToolCalls:
+      title: ServerMessageToolCalls
+    ServerMessageTransferDestinationRequest:
+      title: ServerMessageTransferDestinationRequest
+    ServerMessageTransferUpdate:
+      title: ServerMessageTransferUpdate
+    ServerMessageUserInterrupted:
+      title: ServerMessageUserInterrupted
+    ServerMessageLanguageChangeDetected:
+      title: ServerMessageLanguageChangeDetected
+    ServerMessageVoiceInput:
+      title: ServerMessageVoiceInput
+    ServerMessageVoiceRequest:
+      title: ServerMessageVoiceRequest
+    ServerMessageResponseAssistantRequest:
+      title: ServerMessageResponseAssistantRequest
+    ServerMessageResponseKnowledgeBaseRequest:
+      title: ServerMessageResponseKnowledgeBaseRequest
+    ServerMessageResponseToolCalls:
+      title: ServerMessageResponseToolCalls
+    ServerMessageResponseTransferDestinationRequest:
+      title: ServerMessageResponseTransferDestinationRequest
+    ServerMessageResponseVoiceRequest:
+      title: ServerMessageResponseVoiceRequest
+    ClientInboundMessageAddMessage:
+      title: ClientInboundMessageAddMessage
+    ClientInboundMessageControl:
+      title: ClientInboundMessageControl
+    ClientInboundMessageSay:
+      title: ClientInboundMessageSay
+    ClientInboundMessageEndCall:
+      title: ClientInboundMessageEndCall
+    ClientInboundMessageTransfer:
+      title: ClientInboundMessageTransfer
+
   securitySchemes:
     BearerAuth:
       type: http

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -27,6 +27,7 @@ colors:
     light: "#FFFFFF"
     dark: "#0E0E13"
 experimental:
+  openapi-parser-v3: true
   mdx-components:
     - snippets
 css: assets/styles.css

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vapi",
-  "version": "0.63.21"
+  "version": "0.63.35"
 }


### PR DESCRIPTION
## Description
- upgrade to v3 docs parser for improved property rendering, auto-generated examples, error naming, and more
- add `title` overrides for `oneOf` variants in `openapi-overrides.yml`
- upgrade CLI to latest
  
## Testing Steps
- [X] Run the app locally using `fern docs dev` or navigate to preview deployment
