### PR TITLE
chore(fern): Bump SDK generator versions

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -11,7 +11,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.18.6
+        version: 4.21.4
         api:
           settings:
             unions: v1
@@ -49,7 +49,7 @@ groups:
   java-sdk:
     generators:
       - name: fernapi/fern-java-sdk
-        version: 2.35.2
+        version: 2.37.0
         disable-examples: true
         output:
           location: maven
@@ -75,7 +75,7 @@ groups:
   ruby-sdk:
     generators:
       - name: fernapi/fern-ruby-sdk
-        version: 0.8.2
+        version: 0.9.0-rc2
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-ruby
@@ -88,7 +88,7 @@ groups:
   csharp-sdk:
     generators:
       - name: fernapi/fern-csharp-sdk
-        version: 1.17.2
+        version: 1.18.0
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-csharp


### PR DESCRIPTION
## Description

Bump versions for Ruby, Java, Python, C#

Did not bump TypeScript or Go because there are breaking changes (latest versions are here: https://github.com/fern-api/fern?tab=readme-ov-file#sdk-generators)