### PR TITLE
chore: Upgrade the C# generator to 2.0.1

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -88,7 +88,7 @@ groups:
   csharp-sdk:
     generators:
       - name: fernapi/fern-csharp-sdk
-        version: 1.18.0
+        version: 2.0.1
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-csharp
@@ -99,3 +99,9 @@ groups:
         config:
           namespace: Vapi.Net
           client-class-name: VapiClient
+          additional-properties: false
+          enable-forward-compatible-enums: false
+          generate-mock-server-tests: false
+          inline-path-parameters: false
+          simplify-object-dictionaries: true
+          use-discriminated-unions: false


### PR DESCRIPTION
## Description

Upgrade the C# generator to 2.0.1 and set the C# generator configuration options to maintain backwards compatibility. 
  
## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work
