### PR TITLE
fix(python-sdk): upgrade fern python-sdk generator version

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -11,7 +11,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.21.4
+        version: 4.23.2
         api:
           settings:
             unions: v1


### PR DESCRIPTION
tl/dr: python sdks generated with the new generator version (4.23.0 and later) consume much less memory ~72 MB

## Description
We were seeing issues with memory footprint from just importing the vapi python sdk.
After some investigation, we discovered that this was caused by a change in pydantic versions 2.11.0 that caused one of our config specifications to eagerly do schema validation on all types at import type. In a [recent change](https://github.com/fern-api/fern/pull/7559), we modified this configuration to retain the same type safety but to defer schema validation to usage time.
  
## Testing Steps
We did some memory profiling tests to compare the most recent vapi-server-sdk python package against a locally generated preview sdk version to compare the cost of just importing the lib. We observed memory consumption of about 72MB with the new version, which we believe should be feasible for most environments to run.

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
