### PR TITLE
VAP3-879: Update Zapier MCP links

### DIFF
--- a/fern/tools/mcp.mdx
+++ b/fern/tools/mcp.mdx
@@ -34,7 +34,7 @@ First, you need to obtain an MCP server URL from your chosen provider:
 3. Generate or copy your MCP server URL
 
 <Note>
-  For Zapier MCP, visit https://actions.zapier.com/settings/mcp/ to generate your MCP server URL. This URL should be treated as a credential and kept secure.
+  For Zapier MCP, visit https://mcp.zapier.com/mcp/?client=vapi? to generate your MCP server URL. This URL should be treated as a credential and kept secure.
 </Note>
 
 ### 2. Create and Configure MCP Tool
@@ -96,7 +96,7 @@ MCP requests from Vapi include identifying headers to help with context and debu
 This tool uses the following configuration options:
 
 **Required:**
-- `server.url`: The URL of your MCP server (e.g., https://actions.zapier.com/mcp/actions/)
+- `server.url`: The URL of your MCP server (e.g., https://mcp.zapier.com/api/mcp/s/********/mcp)
 
 **Optional:**
 - `server.headers`: Custom headers to include in requests to the MCP server
@@ -133,7 +133,7 @@ Here's how the MCP tool can be used in your assistant's configuration:
           "name": "mcpTools"
         },
         "server": {
-            "url": "https://actions.zapier.com/mcp/actions/"
+            "url": "https://mcp.zapier.com/api/mcp/s/********/mcp"
         }
       }
     ]
@@ -163,7 +163,7 @@ If you need to use Server-Sent Events protocol instead:
           "name": "mcpTools"
         },
         "server": {
-            "url": "https://actions.zapier.com/mcp/actions/",
+            "url": "https://mcp.zapier.com/api/mcp/s/********/mcp",
             "headers": {
               "Authorization": "Bearer your-token",
               "X-Custom-Header": "your-value"
@@ -193,7 +193,7 @@ If you need to use Server-Sent Events protocol instead:
 
 Zapier offers an MCP server that provides access to thousands of app integrations:
 
-1. Go to https://actions.zapier.com/settings/mcp/
+1. Go to https://mcp.zapier.com/mcp/?client=vapi?
 2. Generate your MCP server URL
 3. Add the URL to your MCP tool configuration
 4. Your assistant will now have access to Zapier's extensive integration network


### PR DESCRIPTION
## Description

- Updates links that point to Zapier
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
