### PR TITLE
fix(openapi-overrides): wrong enum syntax

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -75,7 +75,7 @@ groups:
   ruby-sdk:
     generators:
       - name: fernapi/fern-ruby-sdk
-        version: 0.9.0-rc2
+        version: 0.8.2
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-ruby

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -10,20 +10,20 @@ paths:
       x-fern-sdk-group-name:
         - calls
       x-fern-sdk-method-name: list
-    post:    
+    post:
       x-fern-sdk-group-name:
         - calls
       x-fern-sdk-method-name: create
   /call/{id}:
-    get:   
+    get:
       x-fern-sdk-group-name:
         - calls
       x-fern-sdk-method-name: get
-    delete:   
+    delete:
       x-fern-sdk-group-name:
         - calls
       x-fern-sdk-method-name: delete
-    patch:  
+    patch:
       x-fern-sdk-group-name:
         - calls
       x-fern-sdk-method-name: update
@@ -109,25 +109,25 @@ paths:
       x-fern-sdk-group-name:
         - phoneNumbers
       x-fern-sdk-method-name: list
-    post:    
+    post:
       x-fern-sdk-group-name:
         - phoneNumbers
       x-fern-sdk-method-name: create
   /phone-number/{id}:
-    get:    
+    get:
       x-fern-sdk-group-name:
         - phoneNumbers
       x-fern-sdk-method-name: get
-    delete:       
+    delete:
       x-fern-sdk-group-name:
         - phoneNumbers
       x-fern-sdk-method-name: delete
-    patch:       
+    patch:
       x-fern-sdk-group-name:
         - phoneNumbers
       x-fern-sdk-method-name: update
   /squad:
-    get:   
+    get:
       x-fern-sdk-group-name:
         - squads
       x-fern-sdk-method-name: list
@@ -136,42 +136,42 @@ paths:
         - squads
       x-fern-sdk-method-name: create
   /squad/{id}:
-    get:    
+    get:
       x-fern-sdk-group-name:
         - squads
       x-fern-sdk-method-name: get
-    delete:  
+    delete:
       x-fern-sdk-group-name:
         - squads
       x-fern-sdk-method-name: delete
-    patch:  
+    patch:
       x-fern-sdk-group-name:
         - squads
       x-fern-sdk-method-name: update
   /tool:
-    get: 
+    get:
       x-fern-sdk-group-name:
         - tools
       x-fern-sdk-method-name: list
-    post: 
+    post:
       x-fern-sdk-group-name:
         - tools
       x-fern-sdk-method-name: create
   /tool/{id}:
-    get: 
+    get:
       x-fern-sdk-group-name:
         - tools
       x-fern-sdk-method-name: get
-    delete: 
+    delete:
       x-fern-sdk-group-name:
         - tools
       x-fern-sdk-method-name: delete
-    patch: 
+    patch:
       x-fern-sdk-group-name:
         - tools
       x-fern-sdk-method-name: update
   /file:
-    get: 
+    get:
       x-fern-sdk-group-name:
         - files
       x-fern-sdk-method-name: list
@@ -180,10 +180,10 @@ paths:
         - files
       x-fern-sdk-method-name: create
   /file/{id}:
-    get: 
+    get:
       x-fern-sdk-group-name:
         - files
-      x-fern-sdk-method-name: get 
+      x-fern-sdk-method-name: get
     delete:
       x-fern-sdk-group-name:
         - files
@@ -193,7 +193,7 @@ paths:
         - files
       x-fern-sdk-method-name: update
   /knowledge-base:
-    get: 
+    get:
       x-fern-sdk-group-name:
         - knowledgeBases
       x-fern-sdk-method-name: list
@@ -202,7 +202,7 @@ paths:
         - knowledgeBases
       x-fern-sdk-method-name: create
   /knowledge-base/{id}:
-    get: 
+    get:
       x-fern-sdk-group-name:
         - knowledgeBases
       x-fern-sdk-method-name: get
@@ -219,7 +219,7 @@ paths:
       x-fern-sdk-group-name:
         - analytics
       x-fern-sdk-method-name: get
-    get: 
+    get:
       x-fern-ignore: true
   /logs:
     get:
@@ -227,12 +227,14 @@ paths:
       x-fern-sdk-group-name:
         - logs
       x-fern-sdk-method-name: get
-components: 
+components:
   schemas:
     CreateAssistantDTO:
       properties:
         serverMessages:
           items:
+            enum:
+              - "transcript[transcriptType='final']"
             x-fern-enum:
               "transcript[transcriptType='final']":
                 name: FinalTranscript
@@ -240,6 +242,8 @@ components:
       properties:
         serverMessages:
           items:
+            enum:
+              - "transcript[transcriptType='final']"
             x-fern-enum:
               "transcript[transcriptType='final']":
                 name: FinalTranscript
@@ -247,6 +251,8 @@ components:
       properties:
         serverMessages:
           items:
+            enum:
+              - "transcript[transcriptType='final']"
             x-fern-enum:
               "transcript[transcriptType='final']":
                 name: FinalTranscript
@@ -254,6 +260,8 @@ components:
       properties:
         serverMessages:
           items:
+            enum:
+              - "transcript[transcriptType='final']"
             x-fern-enum:
               "transcript[transcriptType='final']":
                 name: FinalTranscript
@@ -261,6 +269,8 @@ components:
       title: ClientMessageTranscript
       properties:
         type:
+          enum:
+            - "transcript[transcriptType='final']"
           x-fern-enum:
             "transcript[transcriptType='final']":
                 name: FinalTranscript
@@ -268,22 +278,26 @@ components:
       title: ServerMessageTranscript
       properties:
         type:
+          enum:
+            - "transcript[transcriptType='final']"
           x-fern-enum:
             "transcript[transcriptType='final']":
                 name: FinalTranscript
-    AssistantUserEditable: 
-      properties: 
-        serverMessages: 
-          items: 
+    AssistantUserEditable:
+      properties:
+        serverMessages:
+          items:
+            enum:
+              - "transcript[transcriptType='final']"
             x-fern-enum:
               "transcript[transcriptType='final']":
-                  name: FinalTranscript            
-    FallbackAzureVoice: 
+                  name: FinalTranscript
+    FallbackAzureVoice:
       title: FallbackAzureVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type-name: FallbackAzureVoiceId
-        oneOf: 
+        oneOf:
           - x-fern-type-name: FallbackAzureVoiceIdEnum
     FallbackDeepgramVoice:
       title: FallbackDeepgramVoice
@@ -343,28 +357,28 @@ components:
           x-fern-type-name: FallbackSmallestAIVoiceId
           oneOf:
             - x-fern-type-name: FallbackSmallestAIVoiceIdEnum
-    AzureVoice: 
+    AzureVoice:
       title: AzureVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type-name: AzureVoiceId
           oneOf:
           - x-fern-type-name: AzureVoiceIdEnum
     DeepgramVoice:
       title: DeepgramVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type-name: DeepgramVoiceId
-          oneOf: 
-            - x-fern-type-name: DeepgramVoiceIdEnum     
-    ElevenLabsVoice: 
+          oneOf:
+            - x-fern-type-name: DeepgramVoiceIdEnum
+    ElevenLabsVoice:
       title: ElevenLabsVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type-name: ElevenLabsVoiceId
-          oneOf: 
-            - x-fern-type-name: ElevenLabsVoiceIdEnum   
-        provider: 
+          oneOf:
+            - x-fern-type-name: ElevenLabsVoiceIdEnum
+        provider:
           x-fern-type: literal<"11labs">
     SmallestAIVoice:
       title: SmallestAIVoice
@@ -373,34 +387,34 @@ components:
           x-fern-type-name: SmallestAIVoiceId
           oneOf:
             - x-fern-type-name: SmallestAIVoiceIdEnum
-    ElevenLabsCredential: 
-      properties: 
-        provider: 
+    ElevenLabsCredential:
+      properties:
+        provider:
           x-fern-type: literal<"11labs">
-    CreateElevenLabsCredentialDTO: 
+    CreateElevenLabsCredentialDTO:
       title: CreateElevenLabsCredentialDTO
-      properties: 
-        provider: 
+      properties:
+        provider:
           x-fern-type: literal<"11labs">
-    UpdateElevenLabsCredentialDTO: 
-      properties: 
-        provider: 
+    UpdateElevenLabsCredentialDTO:
+      properties:
+        provider:
           x-fern-type: literal<"11labs">
-    VoiceLibrary: 
-      properties: 
-        provider: 
-          x-fern-enum: 
-            "11labs": 
+    VoiceLibrary:
+      properties:
+        provider:
+          x-fern-enum:
+            "11labs":
               name: ElevenLabs
-    SyncVoiceLibraryDTO:  
-      properties: 
-        providers: 
-          x-fern-enum: 
-            "11labs": 
+    SyncVoiceLibraryDTO:
+      properties:
+        providers:
+          x-fern-enum:
+            "11labs":
               name: ElevenLabs
-          items: 
-            x-fern-enum: 
-              "11labs": 
+          items:
+            x-fern-enum:
+              "11labs":
                 name: ElevenLabs
     KeypadInputPlan:
       properties:
@@ -412,59 +426,59 @@ components:
               name: Asterisk
             "#":
               name: Hash
-    NeuphonicVoice: 
+    NeuphonicVoice:
       title: NeuphonicVoice
-      properties: 
-        voiceId: 
-          x-fern-type: string      
-    FallbackNeuphonicVoice: 
-      title: FallbackNeuphonicVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type: string
-    LMNTVoice: 
+    FallbackNeuphonicVoice:
+      title: FallbackNeuphonicVoice
+      properties:
+        voiceId:
+          x-fern-type: string
+    LMNTVoice:
       title: LMNTVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type-name: LMNTVoiceId
-          oneOf: 
-            - x-fern-type-name: LMNTVoiceIdEnum       
-    NeetsVoice: 
+          oneOf:
+            - x-fern-type-name: LMNTVoiceIdEnum
+    NeetsVoice:
       title: NeetsVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type-name: NeetsVoiceId
-          oneOf: 
-            - x-fern-type-name: NeetsVoiceIdEnum 
-    OpenAIVoice: 
+          oneOf:
+            - x-fern-type-name: NeetsVoiceIdEnum
+    OpenAIVoice:
       title: OpenAIVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type-name: OpenAIVoiceId
-          oneOf: 
-            - x-fern-type-name: OpenAIVoiceIdEnum        
-    RimeAIVoice: 
+          oneOf:
+            - x-fern-type-name: OpenAIVoiceIdEnum
+    RimeAIVoice:
       title: RimeAIVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type-name: RimeAIVoiceId
-          oneOf: 
-            - x-fern-type-name: RimeAIVoiceIdEnum 
-    PlayHTVoice: 
+          oneOf:
+            - x-fern-type-name: RimeAIVoiceIdEnum
+    PlayHTVoice:
       title: PlayHTVoice
-      properties: 
-        voiceId: 
+      properties:
+        voiceId:
           x-fern-type-name: PlayHTVoiceId
-          oneOf: 
-            - x-fern-type-name: PlayHTVoiceIdEnum               
-    DeepgramTranscriber: 
+          oneOf:
+            - x-fern-type-name: PlayHTVoiceIdEnum
+    DeepgramTranscriber:
       title: DeepgramTranscriber
       properties:
         model:
           $ref: "#/components/schemas/DeepgramTranscriberModel"
         language:
           $ref: "#/components/schemas/DeepgramTranscriberLanguage"
-    DeepgramTranscriberLanguage: 
+    DeepgramTranscriberLanguage:
       type: string
       enum:
         - "bg"
@@ -564,12 +578,12 @@ components:
           name: zhHant
         "zh-TW":
           name: zhTW
-    DeepgramTranscriberModel: 
+    DeepgramTranscriberModel:
       type: string
       enum:
         - "nova-3"
         - "nova-3-general"
-        - "nova-3-medical"            
+        - "nova-3-medical"
         - "nova-2"
         - "nova-2-general"
         - "nova-2-meeting"
@@ -661,14 +675,14 @@ components:
           name: baseVoicemail
         "base-video":
           name: baseVideo
-    FallbackDeepgramTranscriber: 
+    FallbackDeepgramTranscriber:
       title: FallbackDeepgramTranscriber
       properties:
         model:
           $ref: "#/components/schemas/DeepgramTranscriberModel"
         language:
           $ref: "#/components/schemas/DeepgramTranscriberLanguage"
-    FallbackDeepgramTranscriberLanguage: 
+    FallbackDeepgramTranscriberLanguage:
       type: string
       enum:
         - "bg"
@@ -768,12 +782,12 @@ components:
           name: zhHant
         "zh-TW":
           name: zhTW
-    FallbackDeepgramTranscriberModel: 
+    FallbackDeepgramTranscriberModel:
       type: string
       enum:
         - "nova-3"
         - "nova-3-general"
-        - "nova-3-medical"      
+        - "nova-3-medical"
         - "nova-2"
         - "nova-2-general"
         - "nova-2-meeting"
@@ -865,12 +879,12 @@ components:
           name: baseVoicemail
         "base-video":
           name: baseVideo
-    TransferDestinationAssistant: 
+    TransferDestinationAssistant:
       title: TransferDestinationAssistant
-      properties: 
+      properties:
         transferMode:
           $ref: "#/components/schemas/TransferMode"
-    TransferMode: 
+    TransferMode:
       enum:
         - "rolling-history"
         - "swap-system-message-in-history"
@@ -878,14 +892,14 @@ components:
         "rolling-history":
           name: rollingHistory
         "swap-system-message-in-history":
-          name: swapSystemMessageInHistory      
-    ChunkPlan: 
-      properties: 
-        punctuationBoundaries: 
-          items: 
-            $ref: "#/components/schemas/PunctuationBoundary"    
-    PunctuationBoundary: 
-      enum: 
+          name: swapSystemMessageInHistory
+    ChunkPlan:
+      properties:
+        punctuationBoundaries:
+          items:
+            $ref: "#/components/schemas/PunctuationBoundary"
+    PunctuationBoundary:
+      enum:
         - "。"
         - "，"
         - "."
@@ -901,23 +915,23 @@ components:
         - "||"
         - ","
         - ":"
-      x-fern-enum: 
+      x-fern-enum:
         "。":
           name: CIRCLE
           description: "。"
         "，":
           name: FULL_WIDTH_COMMA
           description: "，"
-        ".":  
+        ".":
           name: DOT
           description: "."
-        "!":  
+        "!":
           name: EXCLAMATION
           description: "!"
         "?":
           name: QUESTION
           description: "?"
-        ";": 
+        ";":
           name: SEMICOLON
           description: ";"
         ")":
@@ -926,30 +940,30 @@ components:
         "،":
           name: ARABIC_COMMA
           description: "،"
-        "۔":  
+        "۔":
           name: URDU_FULL_STOP
           description: "۔"
-        "।":  
+        "।":
           name: BENGALI_FULL_STOP
           description: "।"
-        "॥":  
+        "॥":
           name: DOUBLE_DANDA
           description: "॥"
-        "|":  
+        "|":
           name: PIPE
           description: "|"
-        "||": 
+        "||":
           name: DOUBLE_PIPE
           description: "||"
-        ",":  
+        ",":
           name: HALF_WIDTH_COMMA
           description: ","
-        ":":  
+        ":":
           name: COLON
           description: ":"
-    CartesiaExperimentalControls: 
-      properties: 
-        speed: 
+    CartesiaExperimentalControls:
+      properties:
+        speed:
           x-fern-type-name: CartesiaSpeedControl
 
 
@@ -1557,6 +1571,6 @@ components:
     BearerAuth:
       type: http
       scheme: bearer
-      x-fern-bearer: 
+      x-fern-bearer:
         name: apiKey
         env: VAPI_API_KEY


### PR DESCRIPTION
## Description

- Ruby SDK was broken due an invalid OpenAPI override syntax
- This MR fixes the enum 
  
## Testing Steps

- [-] Run the app locally using `fern docs dev` or navigate to preview deployment
- [-] Ensure that the changed pages and code snippets work
