### PR TITLE
Correct voice_id to voiceId in Vapi Typescript SDK

### DIFF
--- a/fern/quickstart/phone.mdx
+++ b/fern/quickstart/phone.mdx
@@ -126,7 +126,7 @@ vapi assistant create
               // Configure the voice
               voice: {
                 provider: 'playht',
-                voice_id: 'jennifer',
+                voiceId: 'jennifer',
               },
               // Set the first message
               firstMessage: 'Hi there, this is Alex from TechSolutions customer support. How can I help you today?',


### PR DESCRIPTION
## Description

<!-- describe the changes as bullet points -->
- I was trying to use the Vapi TypeScript API to create a new agent.
- The code snippet listed on the web/documentation uses `voice_id`, but the SDK expects `voiceId` (camelCase).
- This mismatch causes a TypeScript error:  
  `Object literal may only specify known properties, but 'voice_id' does not exist in type 'PlayHtVoice'. Did you mean to write 'voiceId'?`
- By the way, if you’re looking for an intern who can catch these things (and bring good vibes), I’m your person! Resume here: https://govindup63.github.io/Resume-Achives/
## Testing Steps

- [X] Run the app locally using `fern docs dev` or navigate to preview deployment
- [X] Ensure that the changed pages and code snippets work
