### PR TITLE
Removed call-recording redirect

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -934,8 +934,6 @@ redirects:
     destination: /tools/google-sheets
   - source: /assistants/workflows
     destination: /workflows/quickstart
-  - source: /assistants/call-recording
-    destination: /assistants/call-recording
   - source: /tools/GHL
     destination: /tools/go-high-level
   - source: /challenges-of-realtime-conversation


### PR DESCRIPTION
## Description
Call recording was redirecting to itself causing a loop 

<!-- describe the changes as bullet points -->
- 
  
## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work
