### PR TITLE
Update server events from OpenAPI schema

### DIFF
--- a/fern/server-url/events.mdx
+++ b/fern/server-url/events.mdx
@@ -16,6 +16,11 @@ All messages sent to your Server URL are `POST` requests with this body shape:
 }
 ```
 
+Common metadata included on most events:
+- `phoneNumber`, `timestamp`
+- `artifact` (recording, transcript, messages, etc.)
+- `assistant`, `customer`, `call`, `chat`
+
 Most events are informational and do not require a response. Responses are only expected for these types sent to your Server URL:
 - "assistant-request"
 - "tool-calls"
@@ -168,13 +173,14 @@ Or return an error message to be spoken to the caller:
     "type": "end-of-call-report",
     "endedReason": "hangup",
     "call": { /* Call Object */ },
-    "recordingUrl": "https://.../recordings/1234.wav",
-    "summary": "The user asked about the weather...",
-    "transcript": "AI: How can I help? User: What's the weather? ...",
-    "messages": [
-      { "role": "assistant", "message": "How can I help?" },
-      { "role": "user", "message": "What's the weather?" }
-    ]
+    "artifact": {
+      "recording": { /* Recording object with URLs */ },
+      "transcript": "AI: How can I help? User: What's the weather? ...",
+      "messages": [
+        { "role": "assistant", "message": "How can I help?" },
+        { "role": "user", "message": "What's the weather?" }
+      ]
+    }
   }
 }
 ```
@@ -200,7 +206,8 @@ Sent when an update is committed to the conversation history.
 {
   "message": {
     "type": "conversation-update",
-    "messages": [ /* current conversation messages */ ]
+    "messages": [ /* current conversation messages */ ],
+    "messagesOpenAIFormatted": [ /* openai-formatted messages */ ]
   }
 }
 ```
@@ -216,7 +223,9 @@ Partial and final transcripts from the transcriber.
     "role": "user",
     "transcriptType": "partial",
     "transcript": "I'd like to book...",
-    "isFiltered": false
+    "isFiltered": false,
+    "detectedThreats": [],
+    "originalTranscript": "I'd like to book..."
   }
 }
 ```
@@ -301,7 +310,8 @@ Sent when the transcriber switches based on detected language.
 ```json
 {
   "message": {
-    "type": "language-change-detected"
+    "type": "language-change-detected",
+    "language": "es"
   }
 }
 ```
@@ -320,6 +330,15 @@ When requested in `assistant.serverMessages`, hangup and forwarding are delegate
 }
 ```
 
+```json
+{
+  "message": {
+    "type": "phone-call-control",
+    "request": "hang-up"
+  }
+}
+```
+
 ### Knowledge Base Request (Custom)
 
 If using `assistant.knowledgeBase.provider = "custom-knowledge-base"`.
@@ -328,7 +347,8 @@ If using `assistant.knowledgeBase.provider = "custom-knowledge-base"`.
 {
   "message": {
     "type": "knowledge-base-request",
-    "messages": [ /* conversation so far */ ]
+    "messages": [ /* conversation so far */ ],
+    "messagesOpenAIFormatted": [ /* openai-formatted messages */ ]
   }
 }
 ```


### PR DESCRIPTION
## Description

- Updated server event examples and fields in `fern/server-url/events.mdx` to align with the OpenAPI schema.
- Added a "Common metadata" section for shared event fields.
- Modified `end-of-call-report` to use an `artifact` object for recording, transcript, and messages.
- Included `messagesOpenAIFormatted` in `conversation-update` and `knowledge-base-request` events.
- Added `isFiltered`, `detectedThreats`, and `originalTranscript` fields to the `transcript` event.
- Added the `language` field to the `language-change-detected` event.
- Included a `hang-up` example for the `phone-call-control` event.
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work

---
<a href="https://cursor.com/background-agent?bcId=bc-d022191a-986b-4321-b149-90acf2ff707f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d022191a-986b-4321-b149-90acf2ff707f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

