### PR TITLE
feat: remove warning for vapi numbers ivr navigation

### DIFF
--- a/fern/ivr-navigation.mdx
+++ b/fern/ivr-navigation.mdx
@@ -18,12 +18,10 @@ Some IVRs buffer audio or expect digits at a slower pace. Sending digits too qui
 
 Provider-specific pause characters
 
-- **Twilio / Telnyx**: Use `w` for a 0.5s pause, `W` for a 1s pause. Example: `1w2w3W4#`
+- **Twilio / Telny / Vapi Numbers / BYOK SIP**: Use `w` for a 0.5s pause, `W` for a 1s pause. Example: `1w2w3W4#`
 - **Vonage**: Use `p` for a 0.5s pause. Example: `1p2p3#`
 
 Start with 0.5s pauses and increase only if digits are still missed.
-
-<Warning>Vapi phone numbers and BYOK SIP do not support pause characters at this time.</Warning>
 
 ### 2. Give menus time to finish before responding
 


### PR DESCRIPTION
## Description

Removes warning for vapi numbers ivr navigation as Jambonz confirmed pauses are possible
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
