### PR TITLE
fix: prevent overlap between Vapi widget and Fern Ask AI panel

### DIFF
--- a/fern/custom.js
+++ b/fern/custom.js
@@ -36,9 +36,9 @@ function injectVapiWidget() {
 
     const internalDiv = widget.querySelector('div');
     if (internalDiv) {
-      internalDiv.style.position = 'fixed';
-      internalDiv.style.right = 'var(--ask-ai-panel-width)';
-      internalDiv.style.transition = 'right 0.5s ease-out';
+      internalDiv.style.position = 'fixed !important';
+      internalDiv.style.right = 'var(--ask-ai-panel-width) !important';
+      internalDiv.style.transition = 'right 0.5s ease-out !important';
     }
   };
   document.body.appendChild(script);

--- a/fern/custom.js
+++ b/fern/custom.js
@@ -13,6 +13,11 @@ function injectVapiWidget() {
     return;
   }
 
+  // Add --ask-ai-panel-width CSS variable for widget positioning if it doesn't exist already
+  if (!getComputedStyle(document.documentElement).getPropertyValue('--ask-ai-panel-width').trim()) {
+    document.documentElement.style.setProperty('--ask-ai-panel-width', '0px');
+  }
+
   const script = document.createElement('script');
   script.src = WIDGET_SCRIPT_URL;
   script.async = true;
@@ -28,6 +33,13 @@ function injectVapiWidget() {
     widget.style.zIndex = '9999';
     document.body.appendChild(widget);
     console.log('[custom.js] Widget element appended to DOM');
+
+    const internalDiv = widget.querySelector('div');
+    if (internalDiv) {
+      internalDiv.style.position = 'fixed';
+      internalDiv.style.right = 'var(--ask-ai-panel-width)';
+      internalDiv.style.transition = 'right 0.5s ease-out';
+    }
   };
   document.body.appendChild(script);
   console.log('[custom.js] Widget script appended to DOM');


### PR DESCRIPTION
## Description
- make Vapi widget move based on the current width of Fern Ask AI side panel `var(--ask-ai-panel-width)`
  
## Testing Steps
- [X] Run the app locally using `fern docs dev` or navigate to preview deployment
- [X] Ensure that the changed pages and code snippets work
