### PR TITLE
Add MIT license to docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -650,6 +650,8 @@ navigation:
             collapsed: true
             icon: fa-light fa-user-shield
             contents:
+              - page: MIT license
+                path: security-and-privacy/license.mdx
               - page: TCPA consent guidelines
                 path: tcpa-consent.mdx
               - link: Privacy policy

--- a/fern/security-and-privacy/license.mdx
+++ b/fern/security-and-privacy/license.mdx
@@ -1,0 +1,33 @@
+---
+title: MIT License
+slug: security-and-privacy/license
+---
+
+<Note>
+This documentation is licensed under the MIT License.
+</Note>
+
+```text title="LICENSE" wordWrap
+MIT License
+
+Copyright (c) VapiAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+


### PR DESCRIPTION
## Description

- Added the MIT License to the documentation in a new page (`security-and-privacy/license.mdx`).
- Integrated the new MIT License page into the "Legal" section of the documentation navigation.
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work

---
<a href="https://cursor.com/background-agent?bcId=bc-c1c2105f-019d-432a-bd47-abab0edb4d64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1c2105f-019d-432a-bd47-abab0edb4d64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

