### PR TITLE
Remove logs and kb api endpoints from fern config

### DIFF
--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -197,23 +197,28 @@ paths:
       x-fern-sdk-group-name:
         - knowledgeBases
       x-fern-sdk-method-name: list
+      x-fern-ignore: true
     post:
       x-fern-sdk-group-name:
         - knowledgeBases
       x-fern-sdk-method-name: create
+      x-fern-ignore: true
   /knowledge-base/{id}:
     get:
       x-fern-sdk-group-name:
         - knowledgeBases
       x-fern-sdk-method-name: get
+      x-fern-ignore: true
     delete:
       x-fern-sdk-group-name:
         - knowledgeBases
       x-fern-sdk-method-name: delete
+      x-fern-ignore: true
     patch:
       x-fern-sdk-group-name:
         - knowledgeBases
       x-fern-sdk-method-name: update
+      x-fern-ignore: true
   /analytics:
     post:
       x-fern-sdk-group-name:
@@ -227,6 +232,7 @@ paths:
       x-fern-sdk-group-name:
         - logs
       x-fern-sdk-method-name: get
+      x-fern-ignore: true
 components:
   schemas:
     CreateAssistantDTO:


### PR DESCRIPTION
## Description

- Ignored `logs` and `knowledge-base` API endpoints in `fern/apis/api/openapi-overrides.yml` to remove them from generated SDKs and API documentation.
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work

---
<a href="https://cursor.com/background-agent?bcId=bc-cca68d69-9e29-4943-b807-3f69f9d616d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cca68d69-9e29-4943-b807-3f69f9d616d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

