### PR TITLE
add support for mulaw encoding within websocket transport

### DIFF
--- a/fern/calls/websocket-transport.mdx
+++ b/fern/calls/websocket-transport.mdx
@@ -18,6 +18,8 @@ Vapi's WebSocket transport enables real-time, bidirectional audio communication 
 
 To initiate a call using WebSocket transport:
 
+### PCM Format (16-bit, default)
+
 ```bash
 curl 'https://api.vapi.ai/call' \
   -H 'authorization: Bearer YOUR_API_KEY' \
@@ -30,6 +32,25 @@ curl 'https://api.vapi.ai/call' \
         "format": "pcm_s16le",
         "container": "raw",
         "sampleRate": 16000
+      }
+    }
+  }'
+```
+
+### Mu-Law Format
+
+```bash
+curl 'https://api.vapi.ai/call' \
+  -H 'authorization: Bearer YOUR_API_KEY' \
+  -H 'content-type: application/json' \
+  --data-raw '{
+    "assistantId": "YOUR_ASSISTANT_ID",
+    "transport": {
+      "provider": "vapi.websocket",
+      "audioFormat": {
+        "format": "mulaw",
+        "container": "raw",
+        "sampleRate": 8000
       }
     }
   }'
@@ -61,13 +82,25 @@ When creating a WebSocket call, the audio format can be customized:
 | Parameter   | Description             | Default             |
 |-------------|-------------------------|---------------------|
 | `format`    | Audio encoding format   | `pcm_s16le` (16-bit PCM) |
-| `container` | Audio container format  | `raw` (Raw PCM)         |
-| `sampleRate`| Sample rate in Hz       | `16000` (16kHz)         |
+| `container` | Audio container format  | `raw` (Raw audio)       |
+| `sampleRate`| Sample rate in Hz       | `16000` for PCM, `8000` for Mu-Law |
 
-Currently, Vapi supports only raw PCM (`pcm_s16le` with `raw` container). Additional formats may be supported in future updates.
+### Supported Audio Formats
+
+Vapi supports the following audio formats:
+
+- **`pcm_s16le`**: 16-bit PCM, signed little-endian (default)
+- **`mulaw`**: Mu-Law encoded audio (ITU-T G.711 standard)
+
+Both formats use the `raw` container format for direct audio streaming.
+
+### Format Selection Guidelines
+
+- **PCM (`pcm_s16le`)**: Higher quality audio, larger bandwidth usage. Ideal for high-quality applications.
+- **Mu-Law (`mulaw`)**: Lower bandwidth, telephony-standard encoding. Ideal for telephony integrations and bandwidth-constrained environments.
 
 <Note>
-Vapi automatically converts sample rates as needed. You can stream audio at 8kHz, 44.1kHz, etc., and Vapi will handle conversions seamlessly.
+Vapi automatically converts sample rates as needed. You can stream audio at 8kHz, 44.1kHz, etc., and Vapi will handle conversions seamlessly. The system also handles format conversions internally when needed.
 </Note>
 
 ## Connecting to the WebSocket
@@ -86,8 +119,15 @@ socket.onerror = (error) => console.error("WebSocket error:", error);
 
 The WebSocket supports two types of messages:
 
-- **Binary audio data** (PCM, 16-bit signed little-endian)
+- **Binary audio data** (format depends on your configuration: PCM or Mu-Law)
 - **Text-based JSON control messages**
+
+### Audio Data Format
+
+The binary audio data format depends on your `audioFormat` configuration:
+
+- **PCM (`pcm_s16le`)**: 16-bit signed little-endian samples
+- **Mu-Law (`mulaw`)**: 8-bit Mu-Law encoded samples (ITU-T G.711)
 
 ### Sending Audio Data
 


### PR DESCRIPTION
## Description

<!-- describe the changes as bullet points -->
- Enhanced docs to show support for mulaw encoding within WebSocket transport for calls. 
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
