### PR TITLE
Update scheduling guide terminology

### DIFF
--- a/fern/assistants/examples/appointment-scheduling.mdx
+++ b/fern/assistants/examples/appointment-scheduling.mdx
@@ -1,25 +1,25 @@
 ---
-title: Appointment scheduling assistant
-subtitle: Build an AI receptionist that books, reschedules, and cancels appointments using Assistants and tools
+title: Appointment scheduling squad
+subtitle: Build an AI receptionist that books, reschedules, and cancels appointments using Squads and tools
 slug: assistants/examples/appointment-scheduling
-description: Build a voice AI appointment scheduling assistant with Google Calendar integration, availability checking, and automated confirmations using Vapi Assistants.
+description: Build a voice AI appointment scheduling squad with Google Calendar integration, availability checking, and automated confirmations using Vapi Squads.
 ---
 
 ## Overview
 
-Build an AI-powered appointment scheduling assistant that handles inbound calls for booking, rescheduling, and canceling appointments. This approach uses a single Assistant with tools for calendar availability, customer lookups, and confirmations.
+Build an AI-powered appointment scheduling squad that handles inbound calls for booking, rescheduling, and canceling appointments. This approach uses a single Squad with tools for calendar availability, customer lookups, and confirmations.
 
-**Assistant Capabilities:**
+**Squad Capabilities:**
 * Real-time availability checks and booking
 * Reschedule and cancel with confirmation
 * Customer verification and data lookups
 * SMS/email confirmations via tools
 
 **What You'll Build:**
-* An assistant with a focused prompt for scheduling flows
+* A squad with a focused prompt for scheduling flows
 * Tools for calendar availability and booking
 * Optional CSV knowledge bases for customers/services
-* A phone number attached to your assistant
+* A phone number attached to your squad
 
 ## Prerequisites
 
@@ -118,13 +118,13 @@ Use the Google Calendar integration for availability and booking, or your own AP
 
 ---
 
-## 3. Create the assistant
+## 3. Create the squad
 
 <Tabs>
   <Tab title="Dashboard">
     <Steps>
-      <Step title="Create assistant">
-        - Go to Assistants → Create Assistant → Blank template
+      <Step title="Create squad">
+        - Go to Squads → Create Squad → Blank template
         - Name it `Receptionist`
       </Step>
       <Step title="Configure system prompt">
@@ -139,7 +139,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
         ```
       </Step>
       <Step title="Attach tools">
-        Add your scheduling tools to the assistant and publish.
+        Add your scheduling tools to the squad and publish.
       </Step>
     </Steps>
   </Tab>
@@ -151,7 +151,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
 
     const systemPrompt = `You are an AI receptionist for a barbershop. Verify the customer, then offer booking, rescheduling, or cancellation. Use scheduling tools when needed. Keep replies under 30 words.`;
 
-    const assistant = await vapi.assistants.create({
+    const squad = await vapi.squads.create({
       name: "Receptionist",
       firstMessage: "Welcome to Tony's Barbershop! How can I help you today?",
       model: {
@@ -170,7 +170,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
 
     client = Vapi(token=os.getenv("VAPI_API_KEY"))
 
-    assistant = client.assistants.create(
+    squad = client.squads.create(
         name="Receptionist",
         first_message="Welcome to Tony's Barbershop! How can I help you today?",
         model={
@@ -196,7 +196,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
 
     await vapi.calls.create({
       transport: { type: "web" },
-      assistant: { assistantId: "your-assistant-id" }
+      squad: { squadId: "your-squad-id" }
     });
     ```
 
@@ -204,7 +204,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
     await vapi.calls.create({
       phoneNumberId: "your-phone-number-id",
       customer: { number: "+15551234567" },
-      assistant: { assistantId: "your-assistant-id" }
+      squad: { squadId: "your-squad-id" }
     });
     ```
   </Tab>
@@ -218,7 +218,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
 
     client.calls.create(
         transport={"type": "web"},
-        assistant_id="your-assistant-id",
+        squad_id="your-squad-id",
     )
     ```
 
@@ -226,7 +226,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
     client.calls.create(
         phone_number_id="your-phone-number-id",
         customer={"number": "+15551234567"},
-        assistant_id="your-assistant-id",
+        squad_id="your-squad-id",
     )
     ```
   </Tab>
@@ -237,7 +237,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
       -H "Authorization: Bearer $VAPI_API_KEY" \
       -H "Content-Type: application/json" \
       -d '{
-        "assistant": { "assistantId": "your-assistant-id" }
+        "squad": { "squadId": "your-squad-id" }
       }'
     ```
   </Tab>
@@ -248,7 +248,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
       -H "Authorization: Bearer $VAPI_API_KEY" \
       -H "Content-Type: application/json" \
       -d '{
-        "assistant": { "assistantId": "your-assistant-id" },
+        "squad": { "squadId": "your-squad-id" },
         "phoneNumberId": "your-phone-number-id",
         "customer": { "number": "+15551234567" }
       }'
@@ -260,7 +260,7 @@ Use the Google Calendar integration for availability and booking, or your own AP
 
 <Steps>
   <Step title="Attach a phone number">
-    Create a phone number and assign your assistant. See [Phone calls quickstart](/quickstart/phone).
+    Create a phone number and assign your squad. See [Phone calls quickstart](/quickstart/phone).
   </Step>
   <Step title="Test scenarios">
     - New booking → check availability → book → confirm
@@ -272,6 +272,6 @@ Use the Google Calendar integration for availability and booking, or your own AP
 ## Next steps
 
 - **Tools**: [Google Calendar](/tools/google-calendar), [Custom Tools](/tools/custom-tools)
-- **Structured outputs**: [Extract structured data](/assistants/structured-outputs)
+- **Structured outputs**: [Extract structured data](/squads/structured-outputs)
 - **Multichannel**: [Web integration](/quickstart/web)
 


### PR DESCRIPTION
## Description

- Updated terminology from "assistant" to "squad" in the appointment scheduling guide (`fern/assistants/examples/appointment-scheduling.mdx`).
- Revised front-matter, overview, capabilities, implementation steps, code examples, and relevant links to reflect "squad" terminology.
- Preserved the existing slug (`assistants/examples/appointment-scheduling`) to maintain URL consistency and prevent broken links.
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work

---
<a href="https://cursor.com/background-agent?bcId=bc-f1bb1de9-4500-4e6e-bd98-ed9abc251b64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1bb1de9-4500-4e6e-bd98-ed9abc251b64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

