### PR TITLE
Optimize webhook response time

### DIFF
--- a/fern/server-url/events.mdx
+++ b/fern/server-url/events.mdx
@@ -114,7 +114,7 @@ For inbound phone calls, you can specify the assistant dynamically. If a PhoneNu
 ```
 
 <Note>
-  You must respond to the `assistant-request` webhook within <strong>7.5 seconds end-to-end</strong> (from when we send the request to when your response reaches your server). This limit is fixed and not configurable: Twilio enforces a 15-second cap, and Vapi reserves ~7.5 seconds for call setup. The timeout value shown elsewhere in the dashboard does not apply to this webhook.
+  You must respond to the `assistant-request` webhook within <strong>7.5 seconds end-to-end</strong>. This limit is fixed and not configurable: Twilio enforces a 15-second cap, and Vapi reserves ~7.5 seconds for call setup. The timeout value shown elsewhere in the dashboard does not apply to this webhook.
 
   To avoid timeouts:
   - Return quickly with an existing <code>assistantId</code> or a minimal assistant, then enrich context asynchronously after the call starts using <a href="/calls/call-features">Live Call Control</a>.

--- a/fern/server-url/events.mdx
+++ b/fern/server-url/events.mdx
@@ -114,7 +114,7 @@ For inbound phone calls, you can specify the assistant dynamically. If a PhoneNu
 ```
 
 <Note>
-  You must respond to the `assistant-request` webhook within <strong>7.5 seconds end-to-end</strong>. This limit is fixed and not configurable: Twilio enforces a 15-second cap, and Vapi reserves ~7.5 seconds for call setup. The timeout value shown elsewhere in the dashboard does not apply to this webhook.
+  You must respond to the `assistant-request` webhook within <strong>7.5 seconds end-to-end</strong>. This limit is fixed and not configurable: the telephony provider enforces a 15-second cap, and Vapi reserves ~7.5 seconds for call setup. The timeout value shown elsewhere in the dashboard does not apply to this webhook.
 
   To avoid timeouts:
   - Return quickly with an existing <code>assistantId</code> or a minimal assistant, then enrich context asynchronously after the call starts using <a href="/calls/call-features">Live Call Control</a>.

--- a/fern/server-url/events.mdx
+++ b/fern/server-url/events.mdx
@@ -113,6 +113,14 @@ For inbound phone calls, you can specify the assistant dynamically. If a PhoneNu
 }
 ```
 
+<Note>
+  You must respond to the `assistant-request` webhook within <strong>7.5 seconds end-to-end</strong> (from when we send the request to when your response reaches your server). This limit is fixed and not configurable: Twilio enforces a 15-second cap, and Vapi reserves ~7.5 seconds for call setup. The timeout value shown elsewhere in the dashboard does not apply to this webhook.
+
+  To avoid timeouts:
+  - Return quickly with an existing <code>assistantId</code> or a minimal assistant, then enrich context asynchronously after the call starts using <a href="/calls/call-features">Live Call Control</a>.
+  - Host your webhook close to <code>us-west-2</code> to reduce latency, and target &lt; ~6s to allow for network jitter.
+</Note>
+
 Respond with either an existing assistant ID, a transient assistant, or transfer destination:
 
 ```json


### PR DESCRIPTION
## Description

- Added a `Note` callout to the "Retrieving Assistants" section in `fern/server-url/events.mdx` to clarify the fixed 7.5-second response deadline for the `assistant-request` webhook, explain its reasoning, and provide strategies to avoid timeouts (e.g., using Live Call Control for async context). This addresses a common user pain point regarding webhook timeouts.
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work

---
<a href="https://cursor.com/background-agent?bcId=bc-4879ccf0-b8fe-4716-868d-b5500aead6f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4879ccf0-b8fe-4716-868d-b5500aead6f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

