### PR TITLE
Removed Typo from Docs

### DIFF
--- a/fern/assistants/structured-outputs-quickstart.mdx
+++ b/fern/assistants/structured-outputs-quickstart.mdx
@@ -737,23 +737,6 @@ You can attach multiple structured outputs to extract different types of data:
 
 <Note>The `structuredOutputIds` are UUIDs returned when you create each structured output configuration.</Note>
 
-### Conditional extraction
-
-Use conditional logic in your schema to handle different scenarios:
-
-```json
-{
-  "if": {
-    "properties": {
-      "requestType": {"const": "appointment"}
-    }
-  },
-  "then": {
-    "required": ["preferredDate", "preferredTime"]
-  }
-}
-```
-
 ### Validation patterns
 
 Common validation patterns for reliable extraction:


### PR DESCRIPTION
Removed section for conditional structured outputs (not currently live)

## Description

<!-- describe the changes as bullet points -->
- 
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
