### PR TITLE
Update community expert directory link

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -612,7 +612,7 @@ navigation:
                 href: https://content.vapi.ai/
               - link: Expert Directory
                 icon: fa-light fa-book-user
-                href: https://vapi.ai/creators
+                href: https://vapi.ai/library
               - link: Discord
                 href: https://discord.com/invite/pUFNcf2WmH
                 icon: fa-brands fa-discord
@@ -848,6 +848,8 @@ redirects:
     destination: /api-reference/webhooks/client-message
   - source: "/api-reference/phone-numbers/import-twilio-number"
     destination: "/api-reference/phone-numbers/create-phone-number"
+  - source: /community/expert-directory
+    destination: https://vapi.ai/library
   - source: "api-reference/calls/create-call"
     destination: "https://api.vapi.ai/api#/Calls/CallController_create"
   - source: "/getting_started"


### PR DESCRIPTION
## Description

- Updated the "Expert Directory" link in the community navigation to point to `https://vapi.ai/library`.
- Added a redirect from `/community/expert-directory` to `https://vapi.ai/library` to ensure old links are preserved.
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work

---
<a href="https://cursor.com/background-agent?bcId=bc-0f772526-2ac1-4b75-b586-1b71998c0af5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0f772526-2ac1-4b75-b586-1b71998c0af5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

