### PR TITLE
Add firstMessageMode to transfer assistant 

### DIFF
--- a/fern/calls/assistant-based-warm-transfer.mdx
+++ b/fern/calls/assistant-based-warm-transfer.mdx
@@ -52,6 +52,7 @@ The `function.name` property identifies your transfer tool. Use this name when i
         "mode": "warm-transfer-experimental",
         "transferAssistant": {
           "firstMessage": "Hello, I have a customer on the line. Are you available to take this call?",
+          "firstMessageMode": "assistant-speaks-first", // Default behavior - assistant speaks immediately
           "maxDurationSeconds": 120,
           "silenceTimeoutSeconds": 30,
           "model": {
@@ -86,6 +87,12 @@ The `function.name` property identifies your transfer tool. Use this name when i
 
 <ParamField path="transferAssistant.firstMessage" type="string">
   The initial message spoken by the transfer assistant when the operator answers
+</ParamField>
+
+<ParamField path="transferAssistant.firstMessageMode" type="string" default="assistant-speaks-first">
+  Controls when the transfer assistant delivers the first message:
+  - `assistant-speaks-first`: The assistant immediately speaks the `firstMessage` when the operator answers
+  - `assistant-waits-for-user`: The assistant waits for the operator to speak before responding with the `firstMessage`
 </ParamField>
 
 <ParamField path="transferAssistant.maxDurationSeconds" type="number">
@@ -146,6 +153,7 @@ The transfer assistant can be configured to handle various operator responses:
         "mode": "warm-transfer-experimental",
         "transferAssistant": {
           "firstMessage": "Hi, I have a customer on the line who needs help with their recent order. Are you available?",
+          "firstMessageMode": "assistant-waits-for-user",
           "maxDurationSeconds": 90,
           "model": {
             "provider": "openai",


### PR DESCRIPTION
## Description

<!-- describe the changes as bullet points -->
- Add firstMessageMode to transfer assistant 
  
## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work
