### PR TITLE
Add call transfer response option

### DIFF
--- a/fern/server-url/events.mdx
+++ b/fern/server-url/events.mdx
@@ -146,6 +146,40 @@ Respond with either an existing assistant ID, a transient assistant, or transfer
 { "destination": { "type": "number", "phoneNumber": "+11234567890" } }
 ```
 
+#### Transfer only (skip AI)
+
+If you want to immediately transfer the call without using an assistant, return a `destination` in your `assistant-request` response. This bypasses AI handling.
+
+```json
+{
+  "destination": {
+    "type": "number",
+    "phoneNumber": "+14155552671",
+    "callerId": "{{phoneNumber.number}}",
+    "extension": "101",
+    "message": "Connecting you to support."
+  }
+}
+```
+
+```json
+{
+  "destination": {
+    "type": "sip",
+    "sipUri": "sip:support@example.com",
+    "sipHeaders": { "X-Account": "gold" },
+    "message": "Transferring you now."
+  }
+}
+```
+
+<Note>
+  When `destination` is present in the `assistant-request` response, the call forwards immediately and <code>assistantId</code>, <code>assistant</code>, <code>squadId</code>, and <code>squad</code> are ignored.
+  You must still respond within <strong>7.5 seconds</strong>.
+  To transfer silently, set <code>destination.message</code> to an empty string.
+  For caller ID behavior, see <a href="/calls/call-features">Call features</a>.
+ </Note>
+
 Or return an error message to be spoken to the caller:
 
 ```json


### PR DESCRIPTION
## Description

- Added a new subsection "Transfer only (skip AI)" to the `assistant-request` response documentation.
- This section clarifies how to immediately transfer a call by providing a `destination` in the response, bypassing AI processing.
- Included JSON examples for both number and SIP destinations.
- Added a note explaining that `destination` overrides assistant fields, the response time limit, and how to achieve silent transfers.

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work

---
<a href="https://cursor.com/background-agent?bcId=bc-4ea2a415-e3a5-41f5-87d5-e18922516692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ea2a415-e3a5-41f5-87d5-e18922516692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

