### PR TITLE
Update Fern CLI to configure settings from docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -30,6 +30,9 @@ experimental:
   openapi-parser-v3: true
   mdx-components:
     - snippets
+settings:
+  http-snippets: false
+  dark-mode-code: true
 css: assets/styles.css
 js:
   - path: ./assets/close-playground.js

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vapi",
-  "version": "0.70.1"
+  "version": "0.88.4"
 }


### PR DESCRIPTION
These settings were previously controlled in an internal configuration. Now, we have transferred these settings to be controllable from the `docs.yml`. This PR adds the settings currently enabled in the internal configuration for Vapi to the `docs.yml` file.

We will be deprecating the internal configuration in the coming weeks. Please merge to avoid any disruption in these settings.