### PR TITLE
Enhance OpenAPI workflow with auto-merge step

### DIFF
--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -16,9 +16,16 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update OpenAPI Spec
+        id: sync-openapi
         uses: fern-api/sync-openapi@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: 'update-openapi-spec'
           update_from_source: true
           add_timestamp: true
+      - name: Enable auto-merge
+        if: steps.sync-openapi.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ steps.sync-openapi.outputs.pr_number }} --auto --squash


### PR DESCRIPTION
The key changes:

Added "id: sync-openapi" to the Update OpenAPI Spec step

Added a new "Enable auto-merge" step that runs `gh pr merge --auto --squash` on the created PR