### PR TITLE
Add example for multiple keypad entries

### DIFF
--- a/fern/ivr-navigation.mdx
+++ b/fern/ivr-navigation.mdx
@@ -95,3 +95,39 @@ DTMF sending varies across telephony providers due to internal implementations. 
 - **Try and compare**: Twilio, Telnyx, Vonage, Vapi Numbers, and BYOK SIP
 - **Evaluate**: digit recognition accuracy, latency between digits, and success rate across menu depths.
 
+### 5. Enter multiple keypad entries at once
+
+Some IVRs ask for several digits or letters in a single prompt (for example, by‑name directories that require the first three letters of a last name). In these cases, send all required keys in a single `dtmf` call, using pause characters between keys so the IVR reliably registers them.
+
+- **How**: Use `keys` with a combined sequence, inserting `w` (0.5s pause) or `W` (1s pause) between entries.
+- **Why**: Multiple separate `dtmf` calls can arrive too slowly or be partially ignored; a single combined sequence is more consistent.
+
+```json title="Single dtmf with multiple keys"
+{
+  "role": "tool_calls",
+  "time": 1760710106938,
+  "message": "",
+  "toolCalls": [
+    {
+      "id": "call_CTgHfSj4lNZaqVjByk2eJooc",
+      "type": "function",
+      "function": {
+        "name": "dtmf",
+        "arguments": "{\"keys\": \"w2w1w2\"}"
+      }
+    }
+  ],
+  "secondsFromStart": 25.16
+}
+```
+
+```txt title="By‑name directory example"
+# If the IVR says: "Enter the first 3 letters of the last name"
+# Map letters to digits using the IVR's on‑screen or spoken mapping (e.g., S=7, M=6, I=4)
+dtmf(keys=w7w6w4)
+```
+
+<Info>
+When sending multiple keys at once, keep brief pauses between keys (`w`/`W`) to match the IVR's capture speed. See provider‑specific pause characters above.
+</Info>
+


### PR DESCRIPTION
## Description

- Improved IVR navigation documentation to handle scenarios requiring multiple keypad entries at once (e.g., by-name directories).
- Demonstrated how to send a sequence of DTMF keys, including pauses, within a single `dtmf` tool call for reliable interaction with complex IVRs.
- Provided a JSON example of the `dtmf` call and a by-name directory illustration.

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work

---
<a href="https://cursor.com/background-agent?bcId=bc-8837131e-5f7c-46ac-ad10-49daf7b58aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8837131e-5f7c-46ac-ad10-49daf7b58aa1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

