### PR TITLE
added quickstart videos for evals, structured outputs, and boards

### DIFF
--- a/fern/assistants/structured-outputs-quickstart.mdx
+++ b/fern/assistants/structured-outputs-quickstart.mdx
@@ -8,6 +8,8 @@ slug: assistants/structured-outputs-quickstart
 
 This quickstart guide will help you set up structured outputs to automatically extract customer information from phone calls. In just a few minutes, you'll create a structured output, link it to an assistant, and test data extraction.
 
+<iframe style="border:0;" width="800" height="450" src="https://www.tella.tv/video/cmgu4jpf9000y0cjxccked3ke/embed?b=0&title=0&a=1&loop=0&t=0&muted=0&wt=1" allowfullscreen allowtransparency></iframe>
+
 ### What are structured outputs?
 
 Structured outputs are AI-powered analysis and extraction tools that intelligently process conversation data after calls end. They go beyond simple data extraction to provide intelligent analysis and evaluation. They work by:

--- a/fern/observability/boards-quickstart.mdx
+++ b/fern/observability/boards-quickstart.mdx
@@ -8,6 +8,8 @@ slug: observability/boards-quickstart
 
 Boards is Vapi's custom analytics dashboard system that enables you to create visual dashboards with real-time insights. Build drag-and-drop dashboards tailored to your teams, use cases, and reporting needs—all through the Vapi Dashboard interface.
 
+<div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" src="https://www.tella.tv/video/cmgu88ocu00110bl24dhdan0p/embed?b=0&title=0&a=1&loop=0&t=0&muted=0&wt=1" allowfullscreen allowtransparency></iframe></div>
+
 **Boards allow you to:**
 
 - Add and configure insights (bar charts, line charts, pie charts, text metrics)

--- a/fern/observability/evals-quickstart.mdx
+++ b/fern/observability/evals-quickstart.mdx
@@ -8,6 +8,8 @@ slug: observability/evals-quickstart
 
 This quickstart guide will help you set up automated testing for your AI assistants and squads. In just a few minutes, you'll create mock conversations, define expected behaviors, and validate your agents work correctly before production.
 
+<div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: 0;" src="https://www.tella.tv/video/cmgu6muyb002m0bktda8r6nou/embed?b=0&title=0&a=1&loop=0&t=0&muted=0&wt=1" allowfullscreen allowtransparency></iframe></div>
+
 ### What are Evals?
 
 Evals is Vapi's AI agent testing framework that enables you to systematically test assistants and squads using mock conversations with automated validation. Test your agents by:


### PR DESCRIPTION
## Description

- added quickstart videos for the Observability sections: Evals, Structured Outputs, Boards 
  
## Testing Steps

- [ yes] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ yes] Ensure that the changed pages and code snippets work
