### PR TITLE
Upgrade fern python generator

### DIFF
--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -11,7 +11,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.31.1
+        version: 4.31.2
         api:
           settings:
             unions: v1

--- a/fern/apis/api/openapi.json
+++ b/fern/apis/api/openapi.json
@@ -52620,9 +52620,6 @@
         "properties": {
           "message": {
             "description": "These are all the messages that can be sent to your server before, after and during the call. Configure the messages you'd like to receive in `assistant.serverMessages`.\n\nThe server where the message is sent is determined by the following precedence order:\n\n1. `tool.server.url` (if configured, and only for \"tool-calls\" message)\n2. `assistant.serverUrl` (if configure)\n3. `phoneNumber.serverUrl` (if configured)\n4. `org.serverUrl` (if configured)",
-            "discriminator": {
-              "propertyName": "type"
-            },
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ServerMessageAssistantRequest",

--- a/fern/apis/api/openapi.json
+++ b/fern/apis/api/openapi.json
@@ -52620,6 +52620,9 @@
         "properties": {
           "message": {
             "description": "These are all the messages that can be sent to your server before, after and during the call. Configure the messages you'd like to receive in `assistant.serverMessages`.\n\nThe server where the message is sent is determined by the following precedence order:\n\n1. `tool.server.url` (if configured, and only for \"tool-calls\" message)\n2. `assistant.serverUrl` (if configure)\n3. `phoneNumber.serverUrl` (if configured)\n4. `org.serverUrl` (if configured)",
+            "discriminator": {
+              "propertyName": "type"
+            },
             "oneOf": [
               {
                 "$ref": "#/components/schemas/ServerMessageAssistantRequest",


### PR DESCRIPTION
Brings in change from https://github.com/fern-api/fern/pull/10038

This fixes an issue where e.g. `tool-calls` and `end-of-call-report` payloads get deserialized into `ServerMessageAssistantRequest`, the first union member even when the discriminant is properly applied. This was happening due to the payloads being (only slightly) invalid, and the union deserialization logic going through Pydantic validation.