### PR TITLE
fix: Remove extra closing code block from dynamic variables documentation

### DIFF
--- a/fern/assistants/dynamic-variables.mdx
+++ b/fern/assistants/dynamic-variables.mdx
@@ -116,7 +116,6 @@ Outputs: `Monday, January 01, 2024, 03:45 PM`
 | `%H:%M`        | 15:45         | 24-hour time        |
 | `%A`           | Monday        | Day of week         |
 | `%b %d, %Y`    | Jan 01, 2024  | Abbrev. Month Day   |
-```
 
 ## Using dynamic variables in the dashboard
 
@@ -131,4 +130,3 @@ When you start a call, you must provide a value for each variable (like `name`) 
 <Note>
 Always use double curly braces (`{{variableName}}`) to reference dynamic variables in your prompts and messages.
 </Note>
-</rewritten_file>


### PR DESCRIPTION
## Description

While going through docs, I came across Dynamic Variables which had bad formatting.

<img width="1098" height="932" alt="image" src="https://github.com/user-attachments/assets/d075f114-da14-4ba8-ad1b-36b6f6ef950e" />


Fixed the code block opening and closing. Removed '</rewritten_file>' tag

After fix:

<img width="736" height="643" alt="image" src="https://github.com/user-attachments/assets/a3c5fa39-d432-484a-8e9f-18702267c7fd" />


- 
  
## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work
