### PR TITLE
Added docs on customizing hold audio on transfer

### DIFF
--- a/fern/calls/assistant-based-warm-transfer.mdx
+++ b/fern/calls/assistant-based-warm-transfer.mdx
@@ -107,6 +107,42 @@ The `function.name` property identifies your transfer tool. Use this name when i
   Assistant configuration including provider, model, and system messages that control the transfer assistant's behavior
 </ParamField>
 
+### Customizing hold audio
+
+You can customize the audio played to the customer while they're on hold during the transfer process using the `request-complete` message type. If not specified, Vapi's default ringtone will be used.
+
+<CodeBlocks>
+```json title="Custom Hold Music"
+{
+  "type": "transferCall",
+  "function": {
+    "name": "transferCall"
+  },
+  "destinations": [
+    // ... destination configuration
+  ],
+  "messages": [
+    {
+      "type": "request-start",
+      "content": "I'll transfer you now. Please hold."
+    },
+    {
+      "type": "request-complete",
+      "content": "https://your-domain.com/assets/custom-hold-music.mp3"  // Custom hold audio URL
+    },
+    {
+      "type": "request-failed",
+      "content": "I couldn't complete the transfer."
+    }
+  ]
+}
+```
+</CodeBlocks>
+
+<Tip>
+The `request-complete` message with an audio URL will be played as hold music on the customer's side of the call while the transfer assistant connects with the operator. If you don't specify this message, Vapi's default ringtone will play.
+</Tip>
+
 ## Built-in tools
 
 The transfer assistant has access to two built-in tools:


### PR DESCRIPTION
## Description

<!-- describe the changes as bullet points -->
- Added docs on customizing hold audio on transfer
  
## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work
