### PR TITLE
Note cloud storage options for recordings and transcripts in HIPAA compliance mode

### DIFF
--- a/fern/security-and-privacy/hipaa.mdx
+++ b/fern/security-and-privacy/hipaa.mdx
@@ -65,7 +65,7 @@ When enabling HIPAA compliance, only HIPAA compliant providers may be chosen.
 
 <AccordionGroup>
   <Accordion title="Will enabling HIPAA compliance affect the quality of Vapi's service?">
-    Enabling HIPAA compliance does not degrade the quality of the voice assistant services. However, it limits access to certain features, such as reviewing call logs or transcriptions, that some users may find valuable for quality improvement purposes.
+    Enabling HIPAA compliance does not degrade the quality of the voice assistant services. However, it limits access to certain features, such as reviewing call logs or transcriptions, that some users may find valuable for quality improvement purposes. With HIPAA compliance enabled, storage of transcripts, recordings, and logs on Vapi's servers is disabled. However, Vapi is still able to generate these call artifacts and store them at an external cloud storage location of your choosing such as AWS S3 if the corresponding credentials are provided in the Vapi dashboard.
   </Accordion>
   <Accordion title="Who should use the HIPAA compliance feature?">
     This feature is particularly useful for businesses and organizations in the healthcare sector or any entity that handles sensitive health information and must comply with HIPAA regulations.


### PR DESCRIPTION
## Description

- [Adds a change requested by Shubham](https://discord.com/channels/1211482211119796234/1224791787332173844/1438610888260194456) to note that call recordings can still be enabled in HIPAA compliance mode with the right cloud configurations
  
## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work
