### PR TITLE
VAP10-38: PostHog - Enable cross domain tracking

### DIFF
--- a/fern/custom.js
+++ b/fern/custom.js
@@ -70,9 +70,33 @@ function initializeReo() {
   document.head.appendChild(reoScript);
 }
 
+function configurePostHog() {
+  if (isLocalhost) {
+    console.log('[custom.js] Skipping PostHog configuration on localhost');
+    return;
+  }
+
+  // Wait for PostHog to be initialized by Fern
+  const checkPostHog = setInterval(() => {
+    if (typeof window.posthog !== 'undefined') {
+      clearInterval(checkPostHog);
+      
+      // Configure cross-domain tracking
+      window.posthog.set_config({
+        cross_subdomain_cookie: true,
+        cross_domain: '.vapi.ai',
+        persistence: 'localStorage+cookie'
+      });
+      
+    }
+  }, 100);
+  
+}
+
 function initializeAll() {
   initializeHockeyStack();
   initializeReo();
+  configurePostHog();
   if (ENABLE_VOICE_WIDGET) {
     injectVapiWidget();
   }

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -96,8 +96,6 @@ analytics:
   posthog:
     api-key: ${POSTHOG_PROJECT_API_KEY}
     endpoint: https://us.i.posthog.com
-    cross-subdomain-tracking: true
-    cross-domain: .vapi.ai
   ga4:
     measurement-id: G-BVPB7XB842
 navigation:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -96,6 +96,8 @@ analytics:
   posthog:
     api-key: ${POSTHOG_PROJECT_API_KEY}
     endpoint: https://us.i.posthog.com
+    cross-subdomain-tracking: true
+    cross-domain: .vapi.ai
   ga4:
     measurement-id: G-BVPB7XB842
 navigation:


### PR DESCRIPTION
## Description

PostHog - Enable cross domain tracking

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
