### PR TITLE
VAP-11098 Update the warm transfer docs

### DIFF
--- a/fern/calls/assistant-based-warm-transfer.mdx
+++ b/fern/calls/assistant-based-warm-transfer.mdx
@@ -358,7 +358,7 @@ Configure your transfer assistant to:
 
 <Info>
 - Requires `warm-transfer-experimental` mode
-- Only works with Twilio phone numbers
+- Only works with Twilio, Vapi phone numbers, and SIP trunks. Does not support Telnyx or Vonage
 - Calls are limited by `maxDurationSeconds` to prevent indefinite duration
 - Built-in tools (`transferSuccessful`, `transferCancel`) are predefined and cannot be removed
 - The transfer assistant has access to the previous conversation context


### PR DESCRIPTION
## Description

<!-- describe the changes as bullet points -->
- Updated the warm transfer docs to include vapi number and sip trunking.
  
## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work
