### PR TITLE
Telnyx docs gateway IPs

### DIFF
--- a/fern/advanced/sip/sip-telnyx.mdx
+++ b/fern/advanced/sip/sip-telnyx.mdx
@@ -85,6 +85,9 @@ Integrate your Telnyx SIP trunk with Vapi to enable your AI voice assistants to 
 
   <Step title="Add your Telnyx SIP credentials to Vapi">
     Use the Vapi API to create a SIP trunk credential:
+    <Warning>
+      Use IP addresses in `gateways`. FQDNs like `sip.telnyx.com` return a `400 Bad Request`.
+    </Warning>
     ```bash
     curl -X POST https://api.vapi.ai/credential \
       -H "Content-Type: application/json" \
@@ -94,20 +97,26 @@ Integrate your Telnyx SIP trunk with Vapi to enable your AI voice assistants to 
         "name": "Telnyx Trunk",
         "gateways": [
           {
-            "ip": "sip.telnyx.com",
-            "inboundEnabled": false
+            "ip": "192.76.120.10",
+            "inboundEnabled": true
+          },
+          {
+            "ip": "64.16.250.10",
+            "inboundEnabled": true
           }
         ],
         "outboundAuthenticationPlan": {
           "authUsername": "YOUR_SIP_USERNAME",
           "authPassword": "YOUR_SIP_PASSWORD",
           "sipRegisterPlan": {
-                "realm": "sip.telnyx.com"
-            }
+            "realm": "sip.telnyx.com"
+          }
         }
       }'
     ```
     Replace `YOUR_VAPI_PRIVATE_KEY`, `YOUR_SIP_USERNAME`, and `YOUR_SIP_PASSWORD` with your actual credentials.
+    Replace the gateway IPs with the Telnyx gateway IPs assigned to your trunk.
+    Set `inboundEnabled` to `false` if you only need outbound calls.
     If successful, the response will include an `id` for the created credential, which you'll use in the next step.
   </Step>
 


### PR DESCRIPTION
## Description

- Updated Telnyx SIP integration documentation to specify that gateway IPs, not FQDNs, must be used to avoid 400 Bad Request errors.
- Corrected the example `gateways` configuration to use IP addresses and clarified the `inboundEnabled` setting.
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work

---
<a href="https://cursor.com/background-agent?bcId=bc-ee845a5d-36b5-41f5-ad9b-e86715f53e92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee845a5d-36b5-41f5-ad9b-e86715f53e92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

