### PR TITLE
fix: update docs to reflect query tool support in Chat API

### DIFF
--- a/fern/chat/quickstart.mdx
+++ b/fern/chat/quickstart.mdx
@@ -314,7 +314,6 @@ We'll create a customer support chat for "TechFlow", a software company that wan
 
 <Note>
 **Current chat functionality limitations:**
-- "Query" tool for knowledge-base searches is not yet supported
 - Server webhook events (status updates, end-of-call reports, etc.) are not supported
 </Note>
 

--- a/fern/chat/sms-chat.mdx
+++ b/fern/chat/sms-chat.mdx
@@ -97,7 +97,6 @@ SMS conversations use automatic session management:
 **Current SMS chat limitations:**
 - **10DLC requirement**: Only 10DLC-approved Twilio numbers support assistant responses
 - **Customer-initiated**: Assistants cannot send the first message to customers
-- **Query tool**: Knowledge-base searches are not supported (same as Chat API)
 - **Twilio only**: Other SMS providers are not currently supported
 </Note>
 

--- a/fern/knowledge-base/knowledge-base.mdx
+++ b/fern/knowledge-base/knowledge-base.mdx
@@ -1,7 +1,7 @@
 ---
 title: Introduction to Knowledge Bases
 subtitle: >-
-  Learn how to create and integrate custom knowledge bases into your voice AI
+  Learn how to create and integrate custom knowledge bases into your AI
   assistants.
 slug: knowledge-base
 ---
@@ -21,11 +21,11 @@ slug: knowledge-base
 
 ## **What is Vapi's Knowledge Base?**
 
-A [**Knowledge Base**](/api-reference/knowledge-bases/create) is a collection of custom files that contain information on specific topics or domains. By integrating a Knowledge Base into your voice AI assistant, you can enable it to provide more accurate and informative responses to user queries based on your own data. Knowledge Bases are available through both the Vapi API and dashboard.
+A [**Knowledge Base**](/api-reference/knowledge-bases/create) is a collection of custom files that contain information on specific topics or domains. By integrating a Knowledge Base into your AI assistant, you can enable it to provide more accurate and informative responses to user queries based on your own data. Knowledge Bases are available through both the Vapi API and dashboard.
 
 ### **Why Use a Knowledge Base?**
 
-Using a Knowledge Base with your voice AI assistant offers several benefits:
+Using a Knowledge Base with your AI assistant offers several benefits:
 
 - **Improved accuracy**: Your assistant can provide responses based on your verified information rather than general knowledge.
 - **Enhanced capabilities**: A Knowledge Base enables your assistant to answer complex domain-specific queries with detailed, contextually relevant responses.
@@ -135,7 +135,7 @@ This approach is recommended for developers and users who need precise control o
   Creation](https://youtu.be/i5mvqC5sZxU).
 </Tip>
 
-By following these guidelines, you can create a comprehensive Knowledge Base that enhances the capabilities of your voice AI assistant and provides valuable information to users.
+By following these guidelines, you can create a comprehensive Knowledge Base that enhances the capabilities of your AI assistant and provides valuable information to users.
 
 <Info>
   Currently, Vapi's Knowledge Base functionality supports Google as a provider

--- a/fern/knowledge-base/using-query-tool.mdx
+++ b/fern/knowledge-base/using-query-tool.mdx
@@ -1,13 +1,13 @@
 ---
 title: Using the Query Tool for Knowledge Bases
 subtitle: >-
-  Learn how to configure and use the query tool to enhance your voice AI assistants with custom knowledge bases.
+  Learn how to configure and use the query tool to enhance your AI assistants with custom knowledge bases.
 slug: knowledge-base/using-query-tool
 ---
 
 ## **What is the Query Tool?**
 
-The Query Tool is a powerful feature that allows your voice AI assistant to access and retrieve information from custom knowledge bases. By configuring a query tool with specific file IDs, you can enable your assistant to provide accurate and contextually relevant responses based on your custom data.
+The Query Tool is a powerful feature that allows your AI assistant to access and retrieve information from custom knowledge bases. By configuring a query tool with specific file IDs, you can enable your assistant to provide accurate and contextually relevant responses based on your custom data.
 
 ### **Benefits of Using the Query Tool**
 
@@ -205,4 +205,4 @@ Add clear instructions to your assistant's system messages, **explicitly naming 
   contain clear, well-structured information.
 </Tip>
 
-By following these steps and best practices, you can effectively configure the query tool to enhance your voice AI assistant with custom knowledge bases, making it more informative and responsive to user queries.
+By following these steps and best practices, you can effectively configure the query tool to enhance your AI assistant with custom knowledge bases, making it more informative and responsive to user queries.


### PR DESCRIPTION
## Description

- Remove "Query tool not supported" limitation from Chat API quickstart (`fern/chat/quickstart.mdx`)
- Remove "Query tool not supported" limitation from SMS chat docs (`fern/chat/sms-chat.mdx`)
- Update "voice AI assistant(s)" to "AI assistant(s)" across knowledge base docs (`fern/knowledge-base/using-query-tool.mdx`, `fern/knowledge-base/knowledge-base.mdx`) since the query tool now works for both voice and chat
- Resolves [DEVREL-502]

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
- [ ] Verify `fern/chat/quickstart.mdx` limitations section no longer mentions query tool
- [ ] Verify `fern/chat/sms-chat.mdx` limitations section no longer mentions query tool
- [ ] Verify knowledge base pages use "AI assistant" instead of "voice AI assistant"