### PR TITLE
fix: remove static RTP Media IP addresses from SIP networking docs

### DIFF
--- a/fern/advanced/sip/sip-networking.mdx
+++ b/fern/advanced/sip/sip-networking.mdx
@@ -10,8 +10,8 @@ When you integrate a SIP trunk with Vapi, your firewall and network infrastructu
 
 **In this reference, you'll find:**
 
-- All IP addresses and ports used by Vapi for SIP traffic
-- RTP media port ranges and directionality details
+- All IP addresses and ports used by Vapi for SIP signalling
+- RTP media port ranges, directionality details, and dynamic IP behavior
 - Recommended firewall rules for inbound and outbound traffic
 
 <Note>
@@ -26,9 +26,9 @@ The table below summarizes every IP address, port, and protocol you need to allo
 | --- | --- | --- | --- | --- |
 | SIP signalling | `44.229.228.186`, `44.238.177.138` | `5060` | UDP | Bidirectional |
 | SIP signalling (TLS) | `44.229.228.186`, `44.238.177.138` | `5061` | TLS | Bidirectional |
-| RTP media | `44.229.228.186`, `44.238.177.138` | `40000`-`60000` | UDP | Bidirectional |
+| RTP media | No static IPs (dynamic) | `40000`-`60000` | UDP | Bidirectional |
 
-You can also use the DNS hostname `sip.vapi.ai`, which resolves to both IP addresses listed above.
+You can also use the DNS hostname `sip.vapi.ai`, which resolves to the SIP signalling IP addresses listed above.
 
 ## SIP signalling
 
@@ -58,10 +58,11 @@ The hostname `sip.vapi.ai` resolves to both signalling IP addresses. You can con
 
 ## SIP media (RTP)
 
-RTP media (voice audio) is sourced from the same infrastructure as SIP signalling. The media IP addresses are:
+Vapi does not use static IP addresses for RTP media (voice audio). The media source IP addresses are dynamically assigned and may change between calls. Because of this, you should not rely on allowlisting specific IPs for RTP media traffic.
 
-- `44.229.228.186/32`
-- `44.238.177.138/32`
+<Warning>
+  Unlike SIP signalling, RTP media does **not** originate from a fixed set of IP addresses. Your firewall rules for RTP media should allow traffic based on port ranges rather than specific source IPs.
+</Warning>
 
 ### Port range
 
@@ -81,7 +82,7 @@ Vapi uses **UDP ports 40000 through 60000** for RTP media traffic.
 
 ## Firewall rules
 
-Configure your firewall to allow the following traffic. Both IP addresses must be allowlisted, as Vapi may use either one for any given call.
+Configure your firewall to allow the following traffic. Both SIP signalling IP addresses must be allowlisted, as Vapi may use either one for any given call. For RTP media, allow traffic on the full port range without IP restrictions since Vapi uses dynamic IPs for media.
 
 ### Inbound rules (traffic from Vapi to your network)
 
@@ -91,7 +92,7 @@ Allow these if your SIP provider or PBX needs to receive traffic from Vapi:
 | --- | --- | --- | --- | --- |
 | SIP signalling | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5060` | UDP |
 | SIP signalling (TLS) | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5061` | TLS |
-| RTP media | `44.229.228.186`, `44.238.177.138` | Your media server | `40000`-`60000` | UDP |
+| RTP media | Any (dynamic) | Your media server | `40000`-`60000` | UDP |
 
 ### Outbound rules (traffic from your network to Vapi)
 
@@ -101,23 +102,23 @@ Allow these if your firewall restricts outbound connections:
 | --- | --- | --- | --- | --- |
 | SIP signalling | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5060` | UDP |
 | SIP signalling (TLS) | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5061` | TLS |
-| RTP media | Your media server | `44.229.228.186`, `44.238.177.138` | `40000`-`60000` | UDP |
+| RTP media | Your media server | Any (dynamic) | `40000`-`60000` | UDP |
 
 <Warning>
-  Both IP addresses must be allowed in your firewall rules. Vapi may use either address for signalling or media on any given call. Missing one address can cause intermittent call failures.
+  Both SIP signalling IP addresses must be allowed in your firewall rules. Vapi may use either address for signalling on any given call. Missing one address can cause intermittent call failures. For RTP media, since Vapi uses dynamic IPs, configure your firewall to allow the full port range (`40000`-`60000` UDP) without restricting by source or destination IP.
 </Warning>
 
 ## FAQ
 
 <AccordionGroup>
   <Accordion title="Can I use DNS instead of IP addresses in my firewall rules?">
-    The hostname `sip.vapi.ai` resolves to both Vapi SIP IP addresses. However, if your firewall supports only IP-based rules, add both `44.229.228.186` and `44.238.177.138` explicitly. DNS-based firewall rules depend on TTL and caching behavior, which can lead to gaps during DNS updates.
+    The hostname `sip.vapi.ai` resolves to both Vapi SIP signalling IP addresses. However, if your firewall supports only IP-based rules, add both `44.229.228.186` and `44.238.177.138` explicitly for signalling. DNS-based firewall rules depend on TTL and caching behavior, which can lead to gaps during DNS updates. Note that this DNS hostname applies to SIP signalling only; RTP media uses dynamic IPs that cannot be resolved via DNS.
   </Accordion>
   <Accordion title="Do I need to open the full 40000-60000 port range?">
     Yes. Vapi's RTP stack dynamically allocates ports within this range for each call. You cannot predict which specific port a given call will use, so the entire range must be open for reliable media flow.
   </Accordion>
   <Accordion title="Are the signalling and media IPs the same?">
-    Yes. Vapi's SIP signalling and RTP media are served from the same infrastructure and use the same pair of public IP addresses (`44.229.228.186` and `44.238.177.138`).
+    No. Vapi's SIP signalling uses the static IP addresses `44.229.228.186` and `44.238.177.138`, but RTP media does not use static IP addresses. Media source IPs are dynamically assigned and may vary between calls.
   </Accordion>
   <Accordion title="Does Vapi support SRTP (encrypted media)?">
     Vapi supports TLS for SIP signalling on port 5061. For encrypted media (SRTP), configure your SIP trunk gateway with the `tls/srtp` outbound protocol option. See the [gateway configuration reference](/advanced/sip/troubleshoot-sip-trunk-credential-errors#gateway-configuration-reference) for details.


### PR DESCRIPTION
## Description

- Remove static RTP Media IP addresses (`44.229.228.186` and `44.238.177.138`) from all RTP media sections in the SIP networking documentation
- Update the SIP media (RTP) section to clearly state that Vapi does not use static IPs for RTP media and that media source IPs are dynamically assigned
- Update firewall rules tables to show "Any (dynamic)" for RTP media source/destination IPs instead of the static addresses
- Update the quick reference table to show "No static IPs (dynamic)" for RTP media
- Update FAQ entries to reflect the distinction between static SIP signalling IPs and dynamic RTP media IPs
- SIP signalling IP addresses are unchanged and remain documented as before
- Resolves DEVREL-513

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
- [ ] Verify all SIP signalling IP references (`44.229.228.186`, `44.238.177.138`) are preserved in signalling sections
- [ ] Confirm all RTP media sections no longer reference static IPs
- [ ] Review that the SIP networking page reads coherently end-to-end