### PR TITLE
Add New Vapi Voices section to legacy migration docs

### DIFF
--- a/fern/providers/voice/vapi-voices/legacy-migration.mdx
+++ b/fern/providers/voice/vapi-voices/legacy-migration.mdx
@@ -47,20 +47,6 @@ If you're currently using one of the voices that are staying, no action is requi
 - **New assistants** can no longer be created using legacy voices
 - **After March 1, 2026**, any assistants still using legacy voices will be automatically switched to the default replacement voice (Option 1 in the table below)
 
-## New Vapi Voices
-
-We've also released a new generation of Vapi Voices that you can use with your assistants:
-
-- Emma
-- Nico
-- Neil
-- Sagar
-- Kai
-- Clara
-- Godfrey
-
-These are separate from the replacement voices listed below — they won't be used as automatic fallbacks. But if you're updating your assistant as part of this migration, they're worth trying out. You can preview them in the [Vapi Dashboard](https://dashboard.vapi.ai).
-
 ## Replacement voice mapping
 
 We've selected replacement voices from ElevenLabs using their voice matching tool to find the closest match in tone and style. These voices are priced similarly to your existing voice.
@@ -81,6 +67,20 @@ We've selected replacement voices from ElevenLabs using their voice matching too
 | Kylie | Chanelle - `t5ztDJA7pj9EyW9QIcJ2` | Aryannah - `vOJuCTA36jkG6q1OskrK` | Riley - `kXsOSDWolD7e9l1Z0sbH` |
 
 For voices that are not in the list of voices on the Vapi Dashboard, users will need to check the "Add Voice ID Manually" option and paste the Voice ID in the text box.
+
+## New Vapi Voices
+
+We've also released a new generation of Vapi Voices that you can use with your assistants:
+
+- Emma
+- Nico
+- Neil
+- Sagar
+- Kai
+- Clara
+- Godfrey
+
+These are separate from the replacement voices listed above — they won't be used as automatic fallbacks. But if you're updating your assistant as part of this migration, they're worth trying out. You can preview them in the [Vapi Dashboard](https://dashboard.vapi.ai).
 
 ## FAQs
 

--- a/fern/providers/voice/vapi-voices/legacy-migration.mdx
+++ b/fern/providers/voice/vapi-voices/legacy-migration.mdx
@@ -47,6 +47,20 @@ If you're currently using one of the voices that are staying, no action is requi
 - **New assistants** can no longer be created using legacy voices
 - **After March 1, 2026**, any assistants still using legacy voices will be automatically switched to the default replacement voice (Option 1 in the table below)
 
+## New Vapi Voices
+
+We've also released a new generation of Vapi Voices that you can use with your assistants:
+
+- Emma
+- Nico
+- Neil
+- Sagar
+- Kai
+- Clara
+- Godfrey
+
+These are separate from the replacement voices listed below — they won't be used as automatic fallbacks. But if you're updating your assistant as part of this migration, they're worth trying out. You can preview them in the [Vapi Dashboard](https://dashboard.vapi.ai).
+
 ## Replacement voice mapping
 
 We've selected replacement voices from ElevenLabs using their voice matching tool to find the closest match in tone and style. These voices are priced similarly to your existing voice.


### PR DESCRIPTION
## Description

- Add a "New Vapi Voices" section to the legacy voice migration page (`providers/voice/vapi-voices/legacy-migration`)
- Lists the new generation of Vapi Voices: Emma, Nico, Neil, Sagar, Kai, Clara, and Godfrey
- Placed after the "What this means" section and before the "Replacement voice mapping" table
- Clarifies that these new voices are separate from the automatic fallback replacements
- Links to the Vapi Dashboard for previewing the voices

Resolves DEVREL-518

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
- [ ] Verify the "New Vapi Voices" section appears between "What this means" and "Replacement voice mapping"
- [ ] Verify the Dashboard link works: https://dashboard.vapi.ai