### PR TITLE
fix: update legacy voice migration guide post-March 1

### DIFF
--- a/fern/providers/voice/vapi-voices/legacy-migration.mdx
+++ b/fern/providers/voice/vapi-voices/legacy-migration.mdx
@@ -6,7 +6,7 @@ slug: providers/voice/vapi-voices/legacy-migration
 
 ## Voice availability update
 
-We've updated Vapi Voices. Some legacy voices have been retired while others continue to be available. We've also added new ultra-realistic human voice clones — Emma, Nico, Sagar, Kai, Neil, Clara, and Godfrey — which you can preview in the [Vapi Dashboard](https://dashboard.vapi.ai/).
+We've updated Vapi Voices. Some legacy voices have been retired while others continue to be available. We've also added new ultra-realistic human voice clones — Emma, Nico, Sagar, Kai, Neil, Clara, and Godfrey, with more coming soon — which you can preview in the [Vapi Dashboard](https://dashboard.vapi.ai/).
 
 ### Voices retired on March 1, 2026
 

--- a/fern/providers/voice/vapi-voices/legacy-migration.mdx
+++ b/fern/providers/voice/vapi-voices/legacy-migration.mdx
@@ -1,16 +1,16 @@
 ---
 title: Legacy voice migration guide
-subtitle: Learn to migrate from legacy Vapi Voices before March 1, 2026
+subtitle: Legacy Vapi Voices were retired on March 1, 2026. Here's what changed and how to update if needed.
 slug: providers/voice/vapi-voices/legacy-migration
 ---
 
 ## Voice availability update
 
-We're updating Vapi Voices. Some legacy voices are being phased out while others will continue to be available.
+We've updated Vapi Voices. Some legacy voices have been retired while others continue to be available. We've also added new ultra-realistic human voice clones — Emma, Nico, Sagar, Kai, Neil, Clara, and Godfrey — which you can preview in the [Vapi Dashboard](https://dashboard.vapi.ai/).
 
-### Voices being retired on March 1, 2026
+### Voices retired on March 1, 2026
 
-The following voices will be retired and are no longer available for new assistants:
+The following voices were retired and are no longer available:
 
 - Spencer
 - Neha
@@ -43,16 +43,16 @@ If you're currently using one of the voices that are staying, no action is requi
 
 ## What this means
 
-- **Existing assistants** using these voices will continue to work during the transition period
+- **Existing assistants** that were using legacy voices have been automatically switched to replacement voices (Option 1 in the table below)
 - **New assistants** can no longer be created using legacy voices
-- **After March 1, 2026**, any assistants still using legacy voices will be automatically switched to the default replacement voice (Option 1 in the table below)
+- **As of March 1, 2026**, all assistants that were still using legacy voices have been automatically switched to the default replacement voice (Option 1 in the table below). You can manually change to a different voice at any time.
 
 ## Replacement voice mapping
 
 We've selected replacement voices from ElevenLabs using their voice matching tool to find the closest match in tone and style. These voices are priced similarly to your existing voice.
 
 <Note>
-**Option 1 is the default fallback** — if you don't switch by March 1, your assistant will automatically be switched to the Option 1 voice.
+**Option 1 was the default fallback.** If your assistant was auto-switched and you'd prefer a different voice, you can still manually update to any other available voice — check out our [New Vapi Voices](#new-vapi-voices) below.
 </Note>
 
 | Legacy Voice | Option 1 (Default Fallback) | Option 2 | Option 3 |
@@ -93,8 +93,8 @@ These are separate from the replacement voices listed above — they won't be us
     We used ElevenLabs' voice matching tool to find the most appropriate replacements for each legacy voice based on tone, style, and characteristics. Replacements should not change your pricing.
   </Accordion>
 
-  <Accordion title="What happens if I don't switch by March 1?">
-    Any assistants still using legacy voices after March 1, 2026 will be automatically switched to the Option 1 (default fallback) voice shown in the table above.
+  <Accordion title="What happened if I didn't switch by March 1?">
+    Assistants that were still using legacy voices on March 1, 2026 were automatically switched to the Option 1 (default fallback) voice shown in the table above. If you'd like to change to a different voice, you can do so anytime via the Dashboard or API.
   </Accordion>
 
   <Accordion title="How do I switch my voice now?">
@@ -102,10 +102,6 @@ These are separate from the replacement voices listed above — they won't be us
 
     1. **Dashboard:** Go to your assistant settings and select a new voice from the dropdown
     2. **API:** Update the `voiceId` field in your assistant configuration via the API
-  </Accordion>
-
-  <Accordion title="Can I choose a different replacement voice?">
-    Yes! We provide three recommended options for each legacy voice, but you're free to choose any available voice that fits your needs. We encourage you to switch before March 1 so you can select the voice that works best for you.
   </Accordion>
 
   <Accordion title="I'm an Enterprise customer — can I get help with the transition?">

--- a/fern/providers/voice/vapi-voices/legacy-migration.mdx
+++ b/fern/providers/voice/vapi-voices/legacy-migration.mdx
@@ -27,6 +27,7 @@ The following Vapi Voices will continue to be fully supported and are **not** be
 
 - Elliot
 - Savannah
+- Rohan
 - Leo
 - Zoe
 - Mia
@@ -35,7 +36,6 @@ The following Vapi Voices will continue to be fully supported and are **not** be
 - Dan
 - Leah
 - Tara
-- Rohan
 
 <Note>
 If you're currently using one of the voices that are staying, no action is required on your part.
@@ -80,7 +80,7 @@ We've also released a new generation of Vapi Voices that you can use with your a
 - Clara
 - Godfrey
 
-These are separate from the replacement voices listed above — they won't be used as automatic fallbacks. But if you're updating your assistant as part of this migration, they're worth trying out. You can preview them in the [Vapi Dashboard](https://dashboard.vapi.ai). More voices are coming soon.
+These are separate from the replacement voices listed above — they won't be used as automatic fallbacks. But if you're updating your assistant as part of this migration, they're worth trying out. More voices are coming soon. You can preview them in the [**Vapi Dashboard**](https://dashboard.vapi.ai/).
 
 ## FAQs
 
@@ -112,8 +112,8 @@ These are separate from the replacement voices listed above — they won't be us
     Reach out to [support@vapi.ai](mailto:support@vapi.ai) or contact your account team if you're an Enterprise customer.
   </Accordion>
 
-  <Accordion title="Are the staying voices (Elliot, Savannah, Leo, etc.) affected?">
-    No. Elliot, Savannah, Leo, Zoe, Mia, Jess, Zac, Dan, Leah, Tara, and Rohan are continuing and are not being retired. If you're using one of these voices, no action is required.
+  <Accordion title="Are the staying voices (Elliot, Savannah, Rohan, etc.) affected?">
+    No. Elliot, Savannah, Rohan, Leo, Zoe, Mia, Jess, Zac, Dan, Leah, and Tara are continuing and are not being retired. If you're using one of these voices, no action is required.
   </Accordion>
 
   <Accordion title="Are these voices compatible with specific ElevenLabs models?">

--- a/fern/providers/voice/vapi-voices/legacy-migration.mdx
+++ b/fern/providers/voice/vapi-voices/legacy-migration.mdx
@@ -80,7 +80,7 @@ We've also released a new generation of Vapi Voices that you can use with your a
 - Clara
 - Godfrey
 
-These are separate from the replacement voices listed above — they won't be used as automatic fallbacks. But if you're updating your assistant as part of this migration, they're worth trying out. You can preview them in the [Vapi Dashboard](https://dashboard.vapi.ai).
+These are separate from the replacement voices listed above — they won't be used as automatic fallbacks. But if you're updating your assistant as part of this migration, they're worth trying out. You can preview them in the [Vapi Dashboard](https://dashboard.vapi.ai). More voices are coming soon.
 
 ## FAQs
 


### PR DESCRIPTION
## Description

- Updates legacy voice migration guide copy from future tense to past tense, reflecting that the March 1, 2026 voice retirement has already occurred
- Updates subtitle, intro paragraph, heading, bullet points, callout note, and one FAQ entry to use past tense
- Adds mention of new ultra-realistic voice clones (Emma, Nico, Sagar, Kai, Neil, Clara, Godfrey) in the intro paragraph
- Removes the now-irrelevant "Can I choose a different replacement voice?" FAQ entry
- Adds anchor link to New Vapi Voices section from the replacement mapping callout

Closes VAP8-47

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
- [ ] Verify the `#new-vapi-voices` anchor link resolves correctly on the legacy-migration page
- [ ] Confirm the removed FAQ entry ("Can I choose a different replacement voice?") no longer appears