### PR TITLE
docs: update Vapi Voices page with new voices and retired banner

### DIFF
--- a/fern/providers/voice/vapi-voices.mdx
+++ b/fern/providers/voice/vapi-voices.mdx
@@ -5,7 +5,7 @@ slug: providers/voice/vapi-voices
 ---
 
 <Warning>
-**Voice Update:** Some legacy voices (Spencer, Neha, Harry, Cole, Paige, Hana, Lily, Kylie) are being retired on March 1, 2026. If you're using any of these voices, please review the migration guide. [Learn more →](/providers/voice/vapi-voices/legacy-migration)
+Some legacy voices (Spencer, Neha, Harry, Cole, Paige, Hana, Lily, Kylie) were retired recently. If you were using any of these voices, please review the guide. [Learn more →](/providers/voice/vapi-voices/legacy-migration)
 </Warning>
 
 ## What are Vapi Voices?
@@ -26,16 +26,64 @@ These voices are fully supported and recommended for new assistants.
 ### Elliot
 - **Gender**: Male
 - **Accent**: Canadian
-- **Age**: 25 years old
-- **Characteristics**: Soothing, friendly, professional
+- **Age**: 20s
+- **Characteristics**: Realistic, friendly, professional, soothing
 - **Sample Audio**: <audio controls src="/static/audio/elliot-sample.wav">Your browser does not support the audio element.</audio>
 
 ### Savannah
 - **Gender**: Female
 - **Accent**: American (Southern)
-- **Age**: 25 years old
-- **Characteristics**: Southern American accent
+- **Age**: 20s
+- **Characteristics**: Realistic, straightforward
 - **Sample Audio**: <audio controls src="/static/audio/savannah-sample.wav">Your browser does not support the audio element.</audio>
+
+### Rohan
+- **Gender**: Male
+- **Accent**: Indian American
+- **Age**: 20s
+- **Characteristics**: Realistic, bright, energetic
+
+### Emma <span style={{color: '#22c55e', fontWeight: 'bold', fontSize: '0.75em', verticalAlign: 'super'}}>New</span>
+- **Gender**: Female
+- **Accent**: Asian American
+- **Age**: 20s
+- **Characteristics**: Realistic, warm, conversational
+
+### Clara <span style={{color: '#22c55e', fontWeight: 'bold', fontSize: '0.75em', verticalAlign: 'super'}}>New</span>
+- **Gender**: Female
+- **Accent**: American
+- **Age**: 30s
+- **Characteristics**: Realistic, warm, professional
+
+### Nico <span style={{color: '#22c55e', fontWeight: 'bold', fontSize: '0.75em', verticalAlign: 'super'}}>New</span>
+- **Gender**: Male
+- **Accent**: American
+- **Age**: 20s
+- **Characteristics**: Realistic, young, casual, natural
+
+### Kai <span style={{color: '#22c55e', fontWeight: 'bold', fontSize: '0.75em', verticalAlign: 'super'}}>New</span>
+- **Gender**: Male
+- **Accent**: American
+- **Age**: 30s
+- **Characteristics**: Realistic, friendly, relaxed, approachable
+
+### Sagar <span style={{color: '#22c55e', fontWeight: 'bold', fontSize: '0.75em', verticalAlign: 'super'}}>New</span>
+- **Gender**: Male
+- **Accent**: Indian American
+- **Age**: 20s
+- **Characteristics**: Realistic, steady, professional
+
+### Godfrey <span style={{color: '#22c55e', fontWeight: 'bold', fontSize: '0.75em', verticalAlign: 'super'}}>New</span>
+- **Gender**: Male
+- **Accent**: American
+- **Age**: 20s
+- **Characteristics**: Realistic, young, energetic
+
+### Neil <span style={{color: '#22c55e', fontWeight: 'bold', fontSize: '0.75em', verticalAlign: 'super'}}>New</span>
+- **Gender**: Male
+- **Accent**: Indian American
+- **Age**: 20s
+- **Characteristics**: Realistic, clear, professional
 
 ## How to Use
 


### PR DESCRIPTION
## Description

- Updated the legacy voices banner to reflect that the voices were recently retired (past tense) instead of being retired on a future date
- Updated Elliot and Savannah voice characteristics and age format (from "25 years old" to "20s")
- Added 8 new voice listings: Rohan, Emma, Clara, Nico, Kai, Sagar, Godfrey, and Neil
- Added "New" tags for newly introduced voices: Emma, Clara, Nico, Kai, Sagar, Godfrey, and Neil
- Rohan is an existing voice newly listed on this page (no "New" tag)
- Only Elliot and Savannah retain audio sample previews; no previews for new voices
- Total voices on page: 10 (up from 2)

Resolves DEVREL-522
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
- [ ] Verify that all 10 voices appear in the correct order: Elliot, Savannah, Rohan, Emma, Clara, Nico, Kai, Sagar, Godfrey, Neil
- [ ] Verify the legacy voices banner displays the updated past-tense text
- [ ] Verify "New" tags appear for Emma, Clara, Nico, Kai, Sagar, Godfrey, and Neil
- [ ] Verify Rohan does NOT have a "New" tag
- [ ] Verify audio samples only appear for Elliot and Savannah
- [ ] Verify the "Learn more" link still points to the legacy migration page