### PR TITLE
Pricing page STT clarity

### DIFF
--- a/fern/pricing.mdx
+++ b/fern/pricing.mdx
@@ -70,7 +70,7 @@ For large-scale deployments, we offer:
   </Accordion>
   
   <Accordion title="How is billing calculated?">
-    Billing is calculated based on actual usage - voice minutes, API calls, and storage used. You can monitor usage in real-time in your dashboard.
+    Billing is calculated from usage across Vapi platform fees and provider passthrough costs (for example, transcriber, model, voice, and telephony). Some provider pricing is per stream, so dual-stream configurations can cost more than single-stream configurations. You can monitor usage in real-time in your dashboard.
   </Accordion>
   
   <Accordion title="Can I change plans anytime?">
@@ -111,6 +111,33 @@ For large-scale deployments, we offer:
     Bring your own API keys for providers, Vapi makes requests on your behalf.
   </Card>
 </CardGroup>
+
+### Azure STT pricing clarification
+
+Azure’s published real-time Speech-to-Text base price is typically around **$1.00/hour** (about **$0.0167/min**) **per stream**.
+
+If you see **$0.016/min** in examples, treat it as a **single-stream reference rate**, not the default total for dual-stream calls.
+
+By default, Vapi transcribes **two streams** for many voice pipelines:
+
+- **Customer audio stream**
+- **Assistant audio stream**
+
+Because both streams are sent to Azure STT, the effective rate is typically about:
+
+- **$0.033/min total STT** (2 × $0.0167/min), before any regional/provider-specific differences
+
+<Note>
+For streaming STT, Azure bills based on audio sent to the service. In continuous streaming, silence and pauses are still part of the streamed audio, so your billed minutes usually track stream duration.
+</Note>
+
+To reduce Azure STT cost toward single-stream pricing:
+
+- Enable **`modelOutputInMessagesEnabled: true`** to skip assistant-channel retranscription when supported.
+- This optimization currently requires **ElevenLabs voice** (word-level timestamps are needed for interruption handling).
+- If you use other voice providers, the assistant stream may still be transcribed.
+
+If you use **BYOK (your own Azure credentials)**, Vapi does not charge Azure STT passthrough on your behalf; Azure bills you directly in your own account.
 
 ### Starter Credits
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

-   Clarified Azure STT pricing on the pricing page to explicitly state that Vapi uses dual-channel billing (customer + assistant audio streams), resulting in an effective rate of approximately $0.033/min.
-   Explained that Azure bills continuously for each stream, including periods of silence, which contributes to the observed cost.
-   Added guidance on how to reduce STT costs by enabling `modelOutputInMessagesEnabled: true` (currently supported with ElevenLabs) to utilize single-channel transcription.
-   Updated the FAQ section to reflect provider passthrough billing and the potential for higher costs with multi-stream configurations.
-   Included a note about direct billing when customers use their own Azure credentials (BYOK).

## Testing Steps

-   [x] Run the app locally using `fern docs dev` or navigate to preview deployment
-   [x] Ensure that the changed pages and code snippets work

---
<p><a href="https://cursor.com/agents/bc-87afd4bb-aefa-4cf6-af8f-92d8ce67d23d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87afd4bb-aefa-4cf6-af8f-92d8ce67d23d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->