### PR TITLE
Add Soniox provider to speech config docs

### DIFF
--- a/fern/customization/speech-configuration.mdx
+++ b/fern/customization/speech-configuration.mdx
@@ -55,11 +55,12 @@ This plan defines the parameters for when the assistant begins speaking after th
 
   - **Assembly**: Transcriber that also reports end-of-turn detection. To use Assembly, choose it as your transcriber without setting a separate smart endpointing plan. As transcripts arrive, we consider the `end_of_turn` flag that Assembly sends to mark the end-of-turn, stream to the LLM, and generate a response.
 
+  - **Soniox v4**: Transcriber with built-in semantic endpointing across 60+ languages. Soniox uses a single universal model to detect end-of-turn based on intonation and conversational context rather than silence duration, producing fewer false triggers. To use Soniox, choose it as your transcriber and turn off "Smart Endpointing" in the Start Speaking Plan. Recommended for multi-lingual agents.
+
   **Text-based providers:**
 
   - **Off**: Disabled by default. When smart endpointing is set to "Off", the system will automatically use the transcriber's end-of-turn detection if available. If no transcriber EOT detection is available, the system defaults to LiveKit if the language is set to English or to Vapi's standard endpointing mode.
   - **LiveKit**: Recommended for English conversations as it provides the most sophisticated solution for detecting natural speech patterns and pauses. LiveKit can be fine-tuned using the `waitFunction` parameter to adjust response timing based on the probability that the user is still speaking.
-  - **Vapi**: Recommended for non-English conversations or as an alternative when LiveKit isn't suitable
 
   ![LiveKit Smart Endpointing Configuration](../static/images/advanced-tab/livekit-smart-endpointing.png)
 

--- a/fern/customization/speech-configuration.mdx
+++ b/fern/customization/speech-configuration.mdx
@@ -55,7 +55,7 @@ This plan defines the parameters for when the assistant begins speaking after th
 
   - **Assembly**: Transcriber that also reports end-of-turn detection. To use Assembly, choose it as your transcriber without setting a separate smart endpointing plan. As transcripts arrive, we consider the `end_of_turn` flag that Assembly sends to mark the end-of-turn, stream to the LLM, and generate a response.
 
-  - **Soniox v4**: Transcriber with built-in semantic endpointing across 60+ languages. Soniox uses a single universal model to detect end-of-turn based on intonation and conversational context rather than silence duration, producing fewer false triggers. To use Soniox, choose it as your transcriber and turn off "Smart Endpointing" in the Start Speaking Plan. Recommended for multi-lingual agents.
+  - **Soniox v4**: Transcriber with built-in semantic endpointing across 60+ languages. Soniox uses a single universal model to detect end-of-turn based on intonation and conversational context rather than silence duration, producing fewer false triggers. To use Soniox, choose it as your transcriber and turn off "Smart Endpointing" in the Start Speaking Plan. Recommended for multilingual agents.
 
   **Text-based providers:**
 


### PR DESCRIPTION
## Description

- Added **Soniox v4** as a new entry under "Audio-text based providers" in the Start Speaking Plan section of the speech configuration docs. Soniox provides built-in semantic endpointing across 60+ languages using a single universal model.
- Removed the **Vapi** entry from "Text-based providers" as it is no longer a recommended option.

Resolves DEVREL-545

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
- [ ] Verify the Soniox entry appears under "Audio-text based providers" with correct formatting
- [ ] Verify the Vapi entry is no longer listed under "Text-based providers"