### PR TITLE
fix: clarify hostname vs IP requirements for SIP trunk gateways

### DIFF
--- a/fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx
+++ b/fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx
@@ -36,15 +36,18 @@ This is the most common cause of this error.
 
 ### What happens
 
-Vapi's API accepts both hostnames (for example, `sip.example.com`) and IPv4 addresses (for example, `203.0.113.10`) in the `gateways[].ip` field. However, the underlying SBC only accepts IPv4 addresses. When you provide a hostname, the SBC rejects the gateway configuration.
+Vapi's API accepts both hostnames (for example, `sip.example.com`) and IPv4 addresses (for example, `203.0.113.10`) in the `gateways[].ip` field. However, **hostnames only work for outbound-only gateways**. For inbound-enabled gateways, the SBC requires a numeric IPv4 address to match the origin of incoming SIP requests. When you provide a hostname for an inbound-enabled gateway, the SBC rejects the gateway configuration.
 
 ### How to check
 
-Look at the value you passed in `gateways[].ip`. If it contains letters (for example, `sip.example.com`), it is a hostname. The SBC needs a numeric IPv4 address instead.
+Look at the value you passed in `gateways[].ip` and the `inboundEnabled` setting:
+
+- If `inboundEnabled` is `true` (the default) and `gateways[].ip` contains a hostname (for example, `sip.example.com`), this is the problem. Inbound gateways require a numeric IPv4 address.
+- If `inboundEnabled` is `false` (outbound-only), hostnames are accepted and this is not the cause of your error.
 
 ### How to fix
 
-Resolve the hostname to its IPv4 address, then use that IP directly.
+If your gateway has inbound enabled, resolve the hostname to its IPv4 address, then use that IP directly.
 
 <Steps>
 <Step title="Look up the IP address">
@@ -76,7 +79,7 @@ Replace the hostname with the numeric IPv4 address in your gateway configuration
       "ip": "203.0.113.10",
       "port": 5060,
       "outboundEnabled": true,
-      "inboundEnabled": false
+      "inboundEnabled": true
     }
   ]
 }
@@ -86,8 +89,9 @@ Replace the hostname with the numeric IPv4 address in your gateway configuration
 </Steps>
 
 <Note>
-  Always use the IPv4 address, not the hostname. If your provider's IP changes,
-  you need to update the gateway configuration.
+  Hostnames are supported for outbound-only gateways (`inboundEnabled: false`).
+  For inbound-enabled gateways, always use a numeric IPv4 address. If your
+  provider's IP changes, you need to update the gateway configuration.
 </Note>
 
 ## Inbound enabled on an outbound-only trunk
@@ -157,7 +161,7 @@ The table below lists all available options for each entry in the `gateways` arr
 
 | Option               | Type    | Default   | Description                                                                    |
 | -------------------- | ------- | --------- | ------------------------------------------------------------------------------ |
-| `ip`                 | string  | (required)| IPv4 address of your SIP gateway. Must be a numeric IP address, not a hostname.|
+| `ip`                 | string  | (required)| Server address of your SIP gateway. Use a numeric IPv4 address for inbound-enabled gateways. Hostnames are accepted for outbound-only gateways (`inboundEnabled: false`).|
 | `port`               | number  | `5060`    | SIP signaling port.                                                            |
 | `netmask`            | number  | `32`      | Subnet mask for inbound IP matching. Valid range: 24 to 32.                    |
 | `inboundEnabled`     | boolean | `true`    | Whether this gateway accepts inbound calls. Set to `false` for outbound-only trunks. |


### PR DESCRIPTION
## Description
- Clarify that hostnames ARE supported for outbound-only SIP gateways (`inboundEnabled: false`), but NOT for inbound-enabled gateways
- Update the "Using a hostname instead of an IP address" section with a new "How to check" subsection explaining the distinction between inbound and outbound hostname support
- Add a `<Note>` component summarizing hostname support rules
- Update the gateway configuration reference table's `ip` field description to reflect the nuanced hostname/IP behavior
- Resolves VAP-12899

## Testing Steps
- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
