### PR TITLE
feat: upgrade fern CLI, all generator versions (major) + GH workflow fix

### DIFF
--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -17,7 +17,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Update OpenAPI Spec
         id: sync-openapi
-        uses: fern-api/sync-openapi@v2
+        uses: fern-api/sync-openapi@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: 'update-openapi-spec'
@@ -27,13 +27,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Wait a moment for PR to be fully created
-          sleep 5
-          # Get the most recent PR that starts with update-openapi-spec
-          PR_NUMBER=$(gh pr list --head update-openapi-spec --json number,headRefName --jq 'map(select(.headRefName | startswith("update-openapi-spec"))) | .[0].number')
+          PR_NUMBER=$(gh pr list --json number,headRefName --jq '[.[] | select(.headRefName | startswith("update-openapi-spec"))] | sort_by(.number) | last | .number')
           if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
             echo "Found PR #$PR_NUMBER, enabling auto-merge"
-            gh pr merge $PR_NUMBER --auto --squash
+            gh pr merge "$PR_NUMBER" --auto --squash
           else
             echo "No PR found for branch starting with update-openapi-spec"
           fi

--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -11,7 +11,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.37.1
+        version: 5.2.0
         api:
           settings:
             prefer-undiscriminated-unions-with-literals: true
@@ -29,7 +29,7 @@ groups:
   ts-sdk:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 3.32.0
+        version: 3.60.8
         api:
           settings:
             prefer-undiscriminated-unions-with-literals: true
@@ -51,7 +51,7 @@ groups:
   go-sdk:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.28.3
+        version: 1.32.1
         disable-examples: true
         api:
           settings:
@@ -64,7 +64,7 @@ groups:
   ruby-sdk:
     generators:
       - name: fernapi/fern-ruby-sdk
-        version: 0.8.2
+        version: 1.1.11
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-ruby
@@ -78,7 +78,7 @@ groups:
   csharp-sdk:
     generators:
       - name: fernapi/fern-csharp-sdk
-        version: 2.9.2
+        version: 2.55.3
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-csharp
@@ -99,7 +99,7 @@ groups:
   php-sdk:
     generators:
       - name: fernapi/fern-php-sdk
-        version: 1.18.0
+        version: 2.2.6
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-php
@@ -110,7 +110,7 @@ groups:
   swift-sdk:
     generators:
       - name: fernapi/fern-swift-sdk
-        version: 0.24.1
+        version: 0.29.0
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-swift

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vapi",
-  "version": "3.62.0"
+  "version": "4.53.1"
 }


### PR DESCRIPTION
## Description

**Breaking changes**:
- Upgraded fern CLI: requires minimum generator versions now
- Python 5.0.0: Min Python version raised from 3.8 to 3.10 
- Ruby 1.0.0: Complete rewrite of the generator. Backwards compatible with existing configs/gem names/modules, but generated code structure is entirely new.
- PHP 2.0.0: Guzzle is no longer a hard dependency (moved to suggest/require-dev).
- Swift 0.28.0: Discriminated unions now use direct associated values instead of synthesized nested wrapper structs. Changes the shape of union types in generated code.

No breaking changes for TypeScript, Go, C#.

Read more on the changes here:
https://buildwithfern.com/learn/cli-api-reference/cli-reference/changelog#400
https://buildwithfern.com/learn/sdks/overview (changelog for each language)
  
## Testing Steps
Generated each SDK locally and ensured each SDK compiles and passes tests
