### PR TITLE
fix: remove redundant config from docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -27,7 +27,6 @@ colors:
     light: "#FFFFFF"
     dark: "#0E0E13"
 experimental:
-  openapi-parser-v3: true
   mdx-components:
     - snippets
 settings:


### PR DESCRIPTION
Removed the openapi-parser-v3 experimental feature from the configuration since it is default true
