### PR TITLE
fix: add explicit npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You can suggest edits by making a pull request.
 To run a local development server with hot-reloading you can run the following command
 
 ```sh
+npm install -g fern-api
 fern docs dev
 ```
 


### PR DESCRIPTION
## Description

<!-- describe the changes as bullet points -->

- adds explicit npm install to the setup instruction in `README.md`

## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work