### PR TITLE
fix line break formatting in flush example

### DIFF
--- a/fern/assistants/flush-syntax.mdx
+++ b/fern/assistants/flush-syntax.mdx
@@ -53,8 +53,12 @@ VAPI supports three flush formats with case-insensitive matching:
 <CodeBlocks>
   ```html title="Self-closing (Recommended)"
   <flush />
-  ``` ```html title="Opening tag"
-  <flush>``` ```html title="Closing tag"</flush>
+  ```
+  ```html title="Opening tag"
+  <flush>
+  ```
+  ```html title="Closing tag"
+  </flush>
   ```
 </CodeBlocks>
 


### PR DESCRIPTION
## Description

<!-- describe the changes as bullet points -->

- formatting was wonky

before:

![image.png](https://app.graphite.com/user-attachments/assets/4014fd64-20fc-4f1a-abaa-c7ce28ad53ab.png)

after:

![image.png](https://app.graphite.com/user-attachments/assets/81b32ea6-2297-427d-9ce0-c070791b8030.png)

![image.png](https://app.graphite.com/user-attachments/assets/1b69d5c3-ff43-4639-a1e4-42013321e675.png)

![image.png](https://app.graphite.com/user-attachments/assets/08b8ef4b-f52d-4a29-bcc3-a023eb2ae417.png)



## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work