### PR TITLE
improve clarity of Providers section

### DIFF
--- a/fern/customization/voice-pipeline-configuration.mdx
+++ b/fern/customization/voice-pipeline-configuration.mdx
@@ -192,10 +192,12 @@ Uses AI models to analyze speech patterns, context, and audio cues to predict wh
     - **deepgram-flux**: Deepgram's latest transcriber model with built-in conversational speech recognition. (English only)
     - **assembly**: Transcriber with built-in end-of-turn detection (English only)
 
+    <hr />
   </Tab>
 </Tabs>
 
-**When to use:**
+
+**When to use smart endpointing:**
 
 - **Deepgram Flux**: English conversations using Deepgram as a transcriber. 
 - **Assembly**: Best used when Assembly is already your transcriber provider for English conversations with integrated end-of-turn detection


### PR DESCRIPTION
## Description

<!-- describe the changes as bullet points -->

I found myself very confused when clicking the `Providers` tab on the voice pipeline configuration page because I couldn't immediately tell where the end of the section was when I clicked on Providers

[Screen Recording 2026-04-07 at 10.46.47 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/4abda356-6ffc-478e-813c-6838ce0847d0.mov" />](https://app.graphite.com/user-attachments/video/4abda356-6ffc-478e-813c-6838ce0847d0.mov)

So I added a divider underneath and also clarified what thing we are saying "when to use"

[Screen Recording 2026-04-07 at 10.47.50 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/5674bcd9-0925-4564-a25c-ae3eb7504035.mov" />](https://app.graphite.com/user-attachments/video/5674bcd9-0925-4564-a25c-ae3eb7504035.mov)



## Testing Steps

- [x] Run the app locally using `fern docs dev` or navigate to preview deployment
- [x] Ensure that the changed pages and code snippets work