### PR TITLE
Rename Changelog to "What's New?" and add Oct 2025 – Mar 2026 backfill

### DIFF
--- a/fern/changelog/2026-03-31.mdx
+++ b/fern/changelog/2026-03-31.mdx
@@ -28,24 +28,33 @@ Here's a summary of everything we shipped from October 2025 through March 2026.
 
 ### Transcriber Models (Speech-to-Text)
 
-- **Deepgram Nova-3 Languages** — Added Hebrew, Urdu, Tagalog, and Arabic bilingual support
-- **Cartesia Transcriber** — ink-whisper
-- **Soniox** — stt-rt-v4
+1. **Deepgram Nova-3 Languages**: Added Hebrew, Urdu, Tagalog, and Arabic bilingual support.
+
+2. **Cartesia Transcriber**: ink-whisper.
+
+3. **Soniox**: stt-rt-v4.
 
 ### Intelligence Models (LLM)
 
-- **GPT-5 Family** — OpenAI's latest intelligence models, including GPT-5, 5-Mini, 5-Nano, 5.1, 5.2, 5.4, 5.4-Mini, 5.4-Nano
-- **Claude 4.5–4.6** — Anthropic's latest intelligence models Sonnet 4.5, Opus 4.5, Opus 4.6, Sonnet 4.6
-- **Gemini 3 Flash** — Google's latest intelligence models
-- **Grok 4 Fast** — Reasoning and non-reasoning variants
-- **GPT Realtime Mini**
+1. **GPT-5 Family**: OpenAI's latest intelligence models, including GPT-5, 5-Mini, 5-Nano, 5.1, 5.2, 5.4, 5.4-Mini, 5.4-Nano.
+
+2. **Claude 4.5–4.6**: Anthropic's latest intelligence models Sonnet 4.5, Opus 4.5, Opus 4.6, Sonnet 4.6.
+
+3. **Gemini 3 Flash**: Google's latest intelligence models.
+
+4. **Grok 4 Fast**: Reasoning and non-reasoning variants.
+
+5. **GPT Realtime Mini**: OpenAI's lightweight realtime model.
 
 ### Voice Models (Text-to-Speech)
 
-- **Cartesia** — sonic-3, sonic-3-2026-01-12, sonic-3-2025-10-27
-- **WellSaid** — Caruso (new), legacy
-- **Inworld** — inworld-tts-1 (REST, original), inworld-tts-1.5-max (WebSocket, $10/M chars), inworld-tts-1.5-mini (WebSocket, $5/M chars)
-- **ElevenLabs Scribe v2**
+1. **Cartesia**: sonic-3, sonic-3-2026-01-12, sonic-3-2025-10-27.
+
+2. **WellSaid**: Caruso (new), legacy.
+
+3. **Inworld**: inworld-tts-1 (REST, original), inworld-tts-1.5-max (WebSocket, $10/M chars), inworld-tts-1.5-mini (WebSocket, $5/M chars).
+
+4. **ElevenLabs Scribe v2**: Latest version of ElevenLabs speech-to-text.
 
 ---
 
@@ -53,18 +62,18 @@ Here's a summary of everything we shipped from October 2025 through March 2026.
 
 1. **Structured Outputs Improvements**: Updates to our AI-powered analysis and data extraction tool, including transient structured outputs, audio-based extraction, and regex extraction.
 
-2. **SIP Request Tool + DTMF over SIP INFO**
+2. **SIP Request Tool + DTMF over SIP INFO**: Send SIP requests and DTMF tones via SIP INFO messages during calls.
 
-3. **Variable Passing Between Tool Calls**
+3. **Variable Passing Between Tool Calls**: Pass output variables from one tool call as input to subsequent tool calls.
 
-4. **Encrypted Tool Arguments**
+4. **Encrypted Tool Arguments**: Encrypt sensitive tool arguments to protect data in transit.
 
-5. **Low Confidence Speech Hook**
+5. **Low Confidence Speech Hook**: Hook that triggers when the transcriber returns low-confidence speech results.
 
-6. **Time Elapsed Hook**
+6. **Time Elapsed Hook**: Hook that triggers at specified time intervals during a call.
 
-7. **`assistant.speechStarted` Event**
+7. **assistant.speechStarted Event**: New event fired when the assistant begins speaking.
 
-8. **MCP Improvements** — Bearer auth, `$ref` dereferencing, child tool messages/discovery
+8. **MCP Improvements**: Bearer auth, $ref dereferencing, child tool messages/discovery.
 
-9. **Warm Transfer Improvements** — SIP support, caller ID, context engineering, variable filling
+9. **Warm Transfer Improvements**: SIP support, caller ID, context engineering, variable filling.

--- a/fern/changelog/2026-03-31.mdx
+++ b/fern/changelog/2026-03-31.mdx
@@ -1,0 +1,70 @@
+# What's New: October 2025 – March 2026
+
+Here's a summary of everything we shipped from October 2025 through March 2026.
+
+---
+
+## Platform
+
+1. **Squads v2**: Visual builder to simplify sophisticated multi-assistant orchestration with seamless handoffs between specialized agents.
+
+2. **Composer (Alpha)**: Intelligent assistant inside the dashboard that allows you to describe what you need through plain text prompts to help build, adjust, and debug voice agents.
+
+3. **Simulations (Alpha)**: Voice agent testing feature to build confidence through enabling systematic, AI-powered testing in specific scenarios with evaluation of outcomes.
+
+4. **Monitoring & Issues**: Automated call quality monitoring with trigger-based issue detection, alerting, and resolution suggestions.
+
+5. **HIPAA with Data Retention**: New compliance mode with private storage and in-dashboard toggle/purchase flow — available for additional cost.
+
+6. **Zero Data Retention**: Compliance mode that keeps context data during call as needed to execute tasks and retains no data afterwards.
+
+7. **Consolidated Logs**: Unified log viewing into a single page.
+
+8. **Vapi Voices**: 12 new ultra-realistic voices released, optimized for latency and cost with adjustable speed controls exposed. 8 legacy voices deprecated.
+
+---
+
+## New Models & Provider Support
+
+### Transcriber Models (Speech-to-Text)
+
+- **Deepgram Nova-3 Languages** — Added Hebrew, Urdu, Tagalog, and Arabic bilingual support
+- **Cartesia Transcriber** — ink-whisper
+- **Soniox** — stt-rt-v4
+
+### Intelligence Models (LLM)
+
+- **GPT-5 Family** — OpenAI's latest intelligence models, including GPT-5, 5-Mini, 5-Nano, 5.1, 5.2, 5.4, 5.4-Mini, 5.4-Nano
+- **Claude 4.5–4.6** — Anthropic's latest intelligence models Sonnet 4.5, Opus 4.5, Opus 4.6, Sonnet 4.6
+- **Gemini 3 Flash** — Google's latest intelligence models
+- **Grok 4 Fast** — Reasoning and non-reasoning variants
+- **GPT Realtime Mini**
+
+### Voice Models (Text-to-Speech)
+
+- **Cartesia** — sonic-3, sonic-3-2026-01-12, sonic-3-2025-10-27
+- **WellSaid** — Caruso (new), legacy
+- **Inworld** — inworld-tts-1 (REST, original), inworld-tts-1.5-max (WebSocket, $10/M chars), inworld-tts-1.5-mini (WebSocket, $5/M chars)
+- **ElevenLabs Scribe v2**
+
+---
+
+## Developer Tools & API
+
+1. **Structured Outputs Improvements**: Updates to our AI-powered analysis and data extraction tool, including transient structured outputs, audio-based extraction, and regex extraction.
+
+2. **SIP Request Tool + DTMF over SIP INFO**
+
+3. **Variable Passing Between Tool Calls**
+
+4. **Encrypted Tool Arguments**
+
+5. **Low Confidence Speech Hook**
+
+6. **Time Elapsed Hook**
+
+7. **`assistant.speechStarted` Event**
+
+8. **MCP Improvements** — Bearer auth, `$ref` dereferencing, child tool messages/discovery
+
+9. **Warm Transfer Improvements** — SIP support, caller ID, context engineering, variable filling

--- a/fern/changelog/2026-03-31.mdx
+++ b/fern/changelog/2026-03-31.mdx
@@ -1,6 +1,6 @@
 # What's New: October 2025 – March 2026
 
-Here's a summary of everything we shipped from October 2025 through March 2026.
+Here's a summary of major items shipped from October 2025 through March 2026.
 
 ---
 

--- a/fern/changelog/2026-03-31.mdx
+++ b/fern/changelog/2026-03-31.mdx
@@ -52,7 +52,7 @@ Here's a summary of everything we shipped from October 2025 through March 2026.
 
 2. **WellSaid**: Caruso (new), legacy.
 
-3. **Inworld**: inworld-tts-1 (REST, original), inworld-tts-1.5-max (WebSocket, $10/M chars), inworld-tts-1.5-mini (WebSocket, $5/M chars).
+3. **Inworld**: inworld-tts-1 (REST, original), inworld-tts-1.5-max (WebSocket, \$10/M chars), inworld-tts-1.5-mini (WebSocket, \$5/M chars).
 
 4. **ElevenLabs Scribe v2**: Latest version of ElevenLabs speech-to-text.
 

--- a/fern/changelog/overview.mdx
+++ b/fern/changelog/overview.mdx
@@ -1,14 +1,14 @@
 ---
-slug: changelog
+slug: whats-new
 ---
 <Card
-  title={<div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', color: 'inherit' }} onClick={() => document.querySelector('input[type="email"]').focus()}>Get the (almost) daily changelog</div>}
+  title={<div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', color: 'inherit' }} onClick={() => document.querySelector('input[type="email"]').focus()}>Subscribe to the latest product updates</div>}
   icon="envelope"
   iconType="solid"
 >
   <form
     method="POST"
-    action="https://customerioforms.com/forms/submit_action?site_id=5f95a74ff6539f0bc48f&form_id=01jk7tf2khhf5satn62531qe25&success_url=https://docs.vapi.ai/changelog"
+    action="https://customerioforms.com/forms/submit_action?site_id=5f95a74ff6539f0bc48f&form_id=01jk7tf2khhf5satn62531qe25&success_url=https://docs.vapi.ai/whats-new"
     className="subscribe-form"
     style={{margin: '1rem 0'}}
     onSubmit={(e) => {

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -76,8 +76,8 @@ tabs:
     icon: fa-light fa-square-terminal
     slug: cli
   changelog:
-    display-name: Changelog
-    slug: changelog
+    display-name: What's New
+    slug: whats-new
     changelog: ./changelog
     icon: history
   mcp:
@@ -856,7 +856,9 @@ redirects:
   - source: /developer-documentation
     destination: /introduction
   - source: /documentation/general/changelog
-    destination: /changelog
+    destination: /whats-new
+  - source: /changelog
+    destination: /whats-new
   - source: /api-reference/assistants/create-assistant
     destination: /api-reference/assistants/create
   - source: /api-reference/assistants/get-assistant

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -76,7 +76,7 @@ tabs:
     icon: fa-light fa-square-terminal
     slug: cli
   changelog:
-    display-name: What's New
+    display-name: What's New?
     slug: whats-new
     changelog: ./changelog
     icon: history


### PR DESCRIPTION
## Summary

- Renamed the changelog tab from "Changelog" to "What's New?" in the navigation
- Updated the URL slug from `/changelog` to `/whats-new`
- Changed the subscription box text from "Get the (almost) daily changelog" to "Subscribe to the latest product updates"
- Updated the form success redirect URL to `/whats-new`
- Added redirect rules for backward compatibility (`/changelog` → `/whats-new`, `/documentation/general/changelog` → `/whats-new`)
- Added a backfill changelog entry covering Oct 2025 – Mar 2026, including:
  - **Platform**: Squads v2, Composer (Alpha), Simulations (Alpha), Monitoring & Issues, HIPAA with Data Retention, Zero Data Retention, Consolidated Logs, Vapi Voices
  - **New Models & Providers**: GPT-5 family, Claude 4.5–4.6, Gemini 3 Flash, Grok 4 Fast, Cartesia sonic-3, Inworld TTS, ElevenLabs Scribe v2, Deepgram Nova-3 languages, Soniox stt-rt-v4
  - **Developer Tools & API**: Structured Outputs improvements, SIP Request Tool + DTMF, variable passing between tool calls, encrypted tool arguments, new hooks (Low Confidence Speech, Time Elapsed), MCP improvements, Warm Transfer improvements

## Test plan

- [x] Run `fern docs dev` or check preview deployment
- [x] Verify "What's New?" tab appears in navigation
- [ ] Confirm the page loads at `/whats-new`
- [ ] Test `/changelog` redirects to `/whats-new`
- [ ] Verify the subscription card shows "Subscribe to the latest product updates"
- [ ] Confirm the backfill entry (2026-03-31) renders correctly with all sections

https://claude.ai/code/session_01PKuW5yr6fMdr6mSwX5Gchy