### PR TITLE
feat: rename Changelog to What's New (UX-93)

### DIFF
--- a/fern/changelog/overview.mdx
+++ b/fern/changelog/overview.mdx
@@ -1,14 +1,14 @@
 ---
-slug: changelog
+slug: whats-new
 ---
 <Card
-  title={<div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', color: 'inherit' }} onClick={() => document.querySelector('input[type="email"]').focus()}>Get the (almost) daily changelog</div>}
+  title={<div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', color: 'inherit' }} onClick={() => document.querySelector('input[type="email"]').focus()}>Subscribe to the latest product updates</div>}
   icon="envelope"
   iconType="solid"
 >
   <form
     method="POST"
-    action="https://customerioforms.com/forms/submit_action?site_id=5f95a74ff6539f0bc48f&form_id=01jk7tf2khhf5satn62531qe25&success_url=https://docs.vapi.ai/changelog"
+    action="https://customerioforms.com/forms/submit_action?site_id=5f95a74ff6539f0bc48f&form_id=01jk7tf2khhf5satn62531qe25&success_url=https://docs.vapi.ai/whats-new"
     className="subscribe-form"
     style={{margin: '1rem 0'}}
     onSubmit={(e) => {

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -1,1112 +1,625 @@
-# yaml-language-server: $schema=https://schema.buildwithfern.dev/docs-yml.json
-
 instances:
-  - url: https://vapi.docs.buildwithfern.com
-    custom-domain: docs.vapi.ai
-    edit-this-page:
-      github:
-        owner: VapiAI
-        repo: docs
-        branch: main
+  - url: docs.vapi.ai
 
-title: Vapi
-favicon: static/images/favicon.ico
+title: Vapi | Docs
+
 logo:
-  light: static/images/logo/logo-light.svg
-  dark: static/images/logo/logo-dark.svg
-  href: /
-  height: 22
+  light: ./docs/static/logo/light.png
+  dark: ./docs/static/logo/dark.png
+
+favicon: ./docs/static/favicon.ico
+
 colors:
   accentPrimary:
-    light: "#12A594"
-    dark: "#12A594"
-  background:
-    light: "#FFFFFF"
-    dark: "#0E0E13"
-  header-background:
-    light: "#FFFFFF"
-    dark: "#0E0E13"
-experimental:
-  mdx-components:
-    - snippets
-settings:
-  http-snippets: false
-  dark-mode-code: true
-css: assets/styles.css
-js:
-  - path: ./assets/close-playground.js
-  - path: ./custom.js
+    light: "#047857"
+    dark: "#34D399"
+
 navbar-links:
-  - type: minimal
-    text: Website
-    href: https://vapi.ai/
-  - type: minimal
-    text: Status
-    href: https://status.vapi.ai/
-  - type: outlined
-    text: Support
-    rightIcon: fa-solid fa-headset
-    href: /support
-  - type: filled
+  - type: secondary
     text: Dashboard
-    rightIcon: fa-solid fa-chevron-right
-    href: https://dashboard.vapi.ai/
-    rounded: true
-footer-links:
-  github: https://github.com/vapiai
-  twitter: https://twitter.com/vapi_ai
-  discord: https://discord.gg/pUFNcf2WmH
-  website: https://vapi.ai/
-  linkedin: https://www.linkedin.com/company/vapi-ai
+    url: https://dashboard.vapi.ai
+  - type: secondary
+    text: Community
+    url: https://discord.gg/pUFNcf2WmH
+  - type: secondary
+    text: Support
+    url: https://vapi.ai/support
+
+announcement:
+  text: "New: Vapi now supports native Text-based conversations! Read more →"
+  url: "/text-based-conversations"
+
+layout:
+  header-height: 70px
+  searchbar-placement: header
+  tabs-placement: header
+  content-width: 55rem
+
+background-image:
+  light: ./docs/static/bg-light.svg
+  dark: ./docs/static/bg-dark.svg
+
+typography:
+  bodyFont:
+    name: Inter
+    paths:
+      - path: ./docs/static/fonts/Inter-Regular.woff2
+        weight: "400"
+        style: normal
+      - path: ./docs/static/fonts/Inter-Medium.woff2
+        weight: "500"
+        style: normal
+      - path: ./docs/static/fonts/Inter-SemiBold.woff2
+        weight: "600"
+        style: normal
+  headingsFont:
+    name: Inter
+    paths:
+      - path: ./docs/static/fonts/Inter-SemiBold.woff2
+        weight: "600"
+        style: normal
+      - path: ./docs/static/fonts/Inter-Bold.woff2
+        weight: "700"
+        style: normal
+  codeFont:
+    name: JetBrains Mono
+    paths:
+      - path: ./docs/static/fonts/JetBrainsMono-Regular.woff2
+        weight: "400"
+        style: normal
+
 tabs:
-  api-reference:
-    slug: api-reference
-    icon: terminal
-    display-name: API Reference
-  documentation:
+  docs:
     display-name: Documentation
-    icon: book
-    slug: documentation
+    slug: docs
+    icon: book-open
+  api-reference:
+    display-name: API Reference
+    slug: api-reference
+    icon: puzzle
   sdks:
     display-name: SDKs
-    icon: code
     slug: sdks
-  cli:
-    display-name: CLI (new)
-    icon: fa-light fa-square-terminal
-    slug: cli
+    icon: code
   changelog:
-    display-name: Changelog
-    slug: changelog
+    display-name: What's New
+    slug: whats-new
     changelog: ./changelog
     icon: history
-  mcp:
-    display-name: MCP
-    icon: fa-light fa-code-branch
-    slug: mcp
-layout:
-  tabs-placement: header
-  searchbar-placement: header
-  header-height: 80px
-  page-width: full
-  content-width: 55rem
-  sidebar-width: 300px
-analytics:
-  posthog:
-    api-key: ${POSTHOG_PROJECT_API_KEY}
-    endpoint: https://us.i.posthog.com
-  ga4:
-    measurement-id: G-BVPB7XB842
+
 navigation:
-  - tab: documentation
-    layout:
-      - section: Get started
-        contents:
-          - page: Introduction
-            icon: fa-light fa-info-circle
-            path: quickstart/introduction.mdx
-          - page: Phone calls
-            icon: fa-solid fa-phone
-            path: quickstart/phone.mdx
-          - page: Web calls
-            icon: fa-light fa-browser
-            path: quickstart/web.mdx
-          - page: Vapi Guides
-            icon: fa-light fa-book-open
-            path: guides.mdx
-          - page: Composer
-            icon: fa-light fa-wand-magic-sparkles
-            path: composer.mdx
-            availability: pre-release
-          - page: CLI quickstart
-            icon: fa-light fa-terminal
-            path: cli/overview.mdx
-
-      - section: Assistants
-        contents:
-          # Removed dedicated introduction; Quickstart is the landing
-          - page: Quickstart
-            path: assistants/quickstart.mdx
-            icon: fa-light fa-rocket
-          - section: Core concepts
-            icon: fa-light fa-brain
-            contents:
-              - page: Transient vs permanent configurations
-                path: assistants/concepts/transient-vs-permanent-configurations.mdx
-          - section: Conversation behavior
-            icon: fa-light fa-comments
-            contents:
-              - page: Variables
-                path: assistants/dynamic-variables.mdx
-              - page: Multilingual support
-                path: customization/multilingual.mdx
-              - page: Personalization with user information
-                path: assistants/personalization.mdx
-              - page: Voice formatting plan
-                path: assistants/voice-formatting-plan.mdx
-              - page: Flush syntax
-                path: assistants/flush-syntax.mdx
-              - page: Background messages
-                path: assistants/background-messages.mdx
-              - page: Idle messages
-                path: assistants/idle-messages.mdx
-              - page: Assistant hooks
-                path: assistants/assistant-hooks.mdx
-              - page: Background speech denoising
-                path: assistants/background-speech-denoising.mdx
-              - page: Pronunciation dictionaries
-                path: assistants/pronunciation-dictionaries.mdx
-          - section: Model configurations
-            icon: fa-light fa-waveform-lines
-            contents:
-              - page: Speech configuration
-                path: customization/speech-configuration.mdx
-              - page: Voice pipeline configuration
-                path: customization/voice-pipeline-configuration.mdx
-              - page: Voice fallback configuration
-                path: voice-fallback-plan.mdx
-              - page: Transcriber fallback configuration
-                path: customization/transcriber-fallback-plan.mdx
-              - page: OpenAI realtime speech-to-speech
-                path: openai-realtime.mdx
-              - page: Provider keys
-                path: customization/provider-keys.mdx
-          - section: Tools
-            path: tools/introduction.mdx
-            collapsed: true
-            icon: fa-light fa-toolbox
-            contents:
-              - page: Built-in call tools
-                path: tools/default-tools.mdx
-                icon: fa-light fa-gear
-              - page: Voicemail tool
-                path: tools/voicemail-tool.mdx
-                icon: fa-light fa-voicemail
-              - page: Custom tools
-                path: tools/custom-tools.mdx
-                icon: fa-light fa-screwdriver-wrench
-              - page: Code tool
-                path: tools/code-tool.mdx
-                icon: fa-light fa-code
-              - page: Client-side tools (Web SDK)
-                path: tools/client-side-websdk.mdx
-                icon: fa-light fa-browser
-              - page: Tool rejection plan
-                path: tools/tool-rejection-plan.mdx
-                icon: fa-light fa-shield-xmark
-              - page: Static variables and aliases
-                path: tools/static-variables-and-aliases.mdx
-                icon: fa-light fa-arrow-right-arrow-left
-              - page: Custom tools troubleshooting
-                path: tools/custom-tools-troubleshooting.mdx
-                icon: fa-light fa-wrench
-              - link: Handoff tool
-                href: /squads/handoff
-                icon: fa-light fa-hand-holding-hand
-              - section: External tools
-                icon: fa-light fa-cubes
-                contents:
-                  - page: Google Calendar
-                    path: tools/google-calendar.mdx
-                    icon: fa-light fa-calendar-days
-                  - page: Google Sheets
-                    path: tools/google-sheets.mdx
-                    icon: fa-brands fa-google-drive
-                  - page: Slack
-                    path: tools/slack.mdx
-                    icon: fa-brands fa-slack
-                  - page: GoHighLevel
-                    path: tools/go-high-level.mdx
-                    icon: fa-light fa-arrow-up
-              - section: Knowledge retrieval
-                path: knowledge-base/knowledge-base.mdx
-                icon: fa-light fa-book
-                contents:
-                  - page: Query tool
-                    path: knowledge-base/using-query-tool.mdx
-                    icon: fa-light fa-magnifying-glass
-                  - page: Custom knowledge base
-                    path: knowledge-base/custom-knowledge-base.mdx
-                    icon: fa-light fa-server
-              - page: Argument encryption
-                path: tools/arguments-encryption.mdx
-                icon: fa-light fa-lock
-          - page: Custom keywords
-            path: customization/custom-keywords.mdx
-            icon: fa-light fa-bullseye
-          - section: Custom voices
-            path: customization/custom-voices/custom-voice.mdx
-            icon: fa-light fa-user
-            contents:
-              - page: Elevenlabs
-                path: customization/custom-voices/elevenlabs.mdx
-              - page: PlayHT
-                path: customization/custom-voices/playht.mdx
-          - page: Custom transcriber
-            path: customization/custom-transcriber.mdx
-            icon: fa-light fa-microphone
-          - page: Custom TTS
-            path: customization/custom-tts.mdx
-            icon: fa-light fa-volume-high
-          - section: Custom LLMs
-            icon: fa-light fa-brain-circuit
-            contents:
-              - page: Fine-tuned OpenAI models
-                path: customization/custom-llm/fine-tuned-openai-models.mdx
-              - page: Bring your own server
-                path: customization/custom-llm/using-your-server.mdx
-              - page: Tool calling integration
-                path: customization/custom-llm/tool-calling-integration.mdx
-          - section: Examples
-            icon: fa-light fa-code
-            contents:
-              - page: Appointment scheduling
-                path: assistants/examples/appointment-scheduling.mdx
-                icon: fa-light fa-calendar-check
-              - page: Lead qualification
-                path: assistants/examples/lead-qualification.mdx
-                icon: fa-light fa-phone
-              - page: Inbound support
-                path: assistants/examples/inbound-support.mdx
-                icon: fa-light fa-phone-volume
-              - page: Voice widget
-                path: assistants/examples/voice-widget.mdx
-                icon: fa-light fa-window-maximize
-              - page: Documentation agent
-                path: assistants/examples/docs-agent.mdx
-                icon: fa-light fa-microphone
-              - page: Support escalation
-                path: assistants/examples/support-escalation.mdx
-                icon: fa-light fa-headset
-              - page: Multilingual agent
-                path: assistants/examples/multilingual-agent.mdx
-                icon: fa-light fa-globe
-
-      - section: Observability
-        contents:
-          - section: Evals
-            icon: fa-light fa-clipboard-check
-            contents:
-              - page: Quickstart
-                path: observability/evals-quickstart.mdx
-                icon: fa-light fa-clipboard-check
-              - page: Advanced
-                path: observability/evals-advanced.mdx
-                icon: fa-light fa-clipboard-check
-          - section: Simulations
-            icon: fa-light fa-flask-vial
-            availability: pre-release
-            contents:
-              - page: Quickstart
-                path: observability/simulations-quickstart.mdx
-                icon: fa-light fa-rocket
-              - page: Advanced
-                path: observability/simulations-advanced.mdx
-                icon: fa-light fa-flask-vial
-          - page: Boards
-            path: observability/boards-quickstart.mdx
-            icon: fa-light fa-chart-line
-          - section: Structured outputs
-            icon: fa-light fa-database
-            contents:
-              - page: Quickstart
-                path: assistants/structured-outputs-quickstart.mdx
-                icon: fa-light fa-rocket
-              - page: Examples
-                path: assistants/structured-outputs-examples.mdx
-                icon: fa-light fa-code
-          - section: Scorecard
-            icon: fa-light fa-star
-            contents:
-              - page: Quickstart
-                path: observability/scorecard-quickstart.mdx
-                icon: fa-light fa-rocket
-
-      - section: Squads
-        contents:
-          - page: Quickstart
-            path: squads-example.mdx
-            icon: fa-light fa-bolt-lightning
-          - page: Overview
-            path: squads.mdx
-            icon: fa-light fa-eye
-          - page: Handoff tool
-            path: squads/handoff.mdx
-            icon: fa-light fa-hand-holding-hand
-          - section: Examples
-            icon: fa-light fa-code
-            contents:
-              - page: Clinic triage & scheduling (handoff tool)
-                path: squads/examples/clinic-triage-scheduling-handoff-tool.mdx
-              - page: Clinic triage & scheduling
-                path: squads/examples/clinic-triage-scheduling.mdx
-              - page: E-commerce order management
-                path: squads/examples/ecommerce-order-management.mdx
-              - page: Property management routing
-                path: squads/examples/property-management.mdx
-              - page: Multilingual support
-                path: squads/examples/multilingual-support.mdx
-              - page: Silent handoffs
-                path: squads/silent-handoffs.mdx
-                icon: fa-light fa-arrow-right-arrow-left
-
-      - section: Best practices
-        contents:
-          - page: Prompting guide
-            path: prompting-guide.mdx
-            icon: fa-light fa-pen-to-square
-          - page: Debugging voice agents
-            path: debugging.mdx
-            icon: fa-light fa-bug
-          - page: Enterprise environments (DEV/UAT/PROD)
-            path: enterprise/dev-uat-prod.mdx
-            icon: fa-light fa-diagram-project
-          - page: IVR navigation
-            path: ivr-navigation.mdx
-            icon: fa-light fa-phone-office
-          - section: Testing
-            collapsed: true
-            icon: fa-light fa-clipboard-check
-            contents:
-              - page: Test suites
-                path: test/test-suites.mdx
-                icon: fa-light fa-check
-              - page: Chat testing
-                path: test/chat-testing.mdx
-                icon: fa-light fa-message
-              - page: Voice testing
-                path: test/voice-testing.mdx
-                icon: fa-light fa-volume-high
-
-      - section: Phone numbers
-        contents:
-          - page: Free Vapi number
-            path: phone-numbers/free-telephony.mdx
-            icon: fa-light fa-gift
-          - page: Inbound SMS
-            path: phone-numbers/inbound-sms.mdx
-            icon: fa-light fa-message
-          - section: Telephony integrations
-            icon: fa-light fa-link
-            contents:
-              - page: Twilio
-                path: phone-numbers/import-twilio.mdx
-              - page: Telnyx
-                path: phone-numbers/telnyx.mdx
-          - section: SIP integration
-            icon: fa-light fa-sitemap
-            contents:
-              - page: SIP telephony
-                path: advanced/sip/sip.mdx
-              - page: SIP trunking
-                path: advanced/sip/sip-trunk.mdx
-              - page: Networking and firewall
-                path: advanced/sip/sip-networking.mdx
-              - section: Providers
-                contents:
-                  - page: Twilio
-                    path: advanced/sip/sip-twilio.mdx
-                  - page: Telnyx
-                    path: advanced/sip/sip-telnyx.mdx
-                  - page: Zadarma
-                    path: advanced/sip/sip-zadarma.mdx
-                  - page: Plivo
-                    path: advanced/sip/sip-plivo.mdx
-                  - page: Amazon Chime SDK
-                    path: advanced/sip/sip-chime.mdx
-              - page: Troubleshoot SIP trunk credential errors
-                path: advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx
-          - page: Phone Number Hooks
-            path: phone-numbers/phone-number-hooks.mdx
-            icon: fa-light fa-webhook
-
-      - section: Calls
-        path: phone-calling.mdx
-        contents:
-          - section: Place calls
-            icon: fa-light fa-phone-arrow-up-right
-            contents:
-              - page: Outbound calls
-                path: calls/call-outbound.mdx
-              - page: WebSocket transport
-                path: calls/websocket-transport.mdx
-          - section: In-call control
-            icon: fa-light fa-sliders
-            contents:
-              - page: Real-time call control
-                path: calls/call-features.mdx
-              - page: Customer join timeout
-                path: calls/customer-join-timeout.mdx
-              - page: Voicemail detection
-                path: calls/voicemail-detection.mdx
-              - section: Transfer calls
-                icon: fa-light fa-phone-arrow-right
-                contents:
-                  - page: Call forwarding
-                    path: call-forwarding.mdx
-                  - page: Assistant-based warm transfer
-                    path: calls/assistant-based-warm-transfer.mdx
-                  - page: Dynamic call transfers
-                    path: calls/call-dynamic-transfers.mdx
-                  - page: On-hold specialist transfer
-                    path: calls/call-handling-with-vapi-and-twilio.mdx
-                  - page: Debug forwarding drops
-                    path: calls/troubleshoot-call-forwarding-drops.mdx
-                    icon: fa-light fa-bug
-              - page: Call queue management
-                path: calls/call-queue-management.mdx
-                icon: fa-light fa-phone-office
-              - page: Call concurrency
-                path: calls/call-concurrency.mdx
-                icon: fa-light fa-gauge-high
-          - page: Call end reasons
-            path: calls/call-ended-reason.mdx
-            icon: fa-light fa-phone-hangup
-          - page: Troubleshoot call errors
-            path: calls/troubleshoot-call-errors.mdx
-            icon: fa-light fa-triangle-exclamation
-          - section: Call insights
-            icon: fa-light fa-chart-simple
-            contents:
-              - page: Call analysis
-                path: assistants/call-analysis.mdx
-                icon: fa-light fa-magnifying-glass-chart
-              - page: Call recording
-                path: assistants/call-recording.mdx
-                icon: fa-light fa-circle-dot
-          # Squads moved to top-level section
-
-      - section: Outbound Campaigns
-        contents:
-          - page: Quickstart
-            path: outbound-campaigns/quickstart.mdx
-            icon: fa-light fa-rocket
-          - page: Overview
-            path: outbound-campaigns/overview.mdx
-            icon: fa-light fa-eye
-
-      - section: Chat
-        contents:
-          - page: Quickstart
-            path: chat/quickstart.mdx
-            icon: fa-light fa-bolt-lightning
-          - page: Streaming
-            path: chat/streaming.mdx
-            icon: fa-light fa-stream
-          - page: Non-streaming
-            path: chat/non-streaming.mdx
-            icon: fa-light fa-message
-          - page: OpenAI compatibility
-            path: chat/openai-compatibility.mdx
-            icon: fa-light fa-puzzle-piece
-          - page: Session management
-            path: chat/session-management.mdx
-            icon: fa-light fa-layer-group
-          - page: Variable substitution
-            path: chat/variable-substitution.mdx
-            icon: fa-light fa-brackets-curly
-          - page: SMS chat
-            path: chat/sms-chat.mdx
-            icon: fa-light fa-comment-sms
-          - page: Web widget
-            path: chat/web-widget.mdx
-            icon: fa-light fa-window-maximize
-
-      - section: Webhooks
-        collapsed: true
-        icon: fa-light fa-webhook
-        path: server-url.mdx
-        contents:
-          - page: Setting server URLs
-            path: server-url/setting-server-urls.mdx
-          - page: Server events
-            path: server-url/events.mdx
-          - page: Spam call rejection
-            path: server-url/spam-call-rejection.mdx
-          - page: Developing locally
-            path: server-url/developing-locally.mdx
-          - page: Server authentication
-            path: server-url/server-authentication.mdx
-
-      - section: Workflows
-        contents:
-          - page: Quickstart
-            path: workflows/quickstart.mdx
-            icon: fa-light fa-rocket
-          - page: Overview
-            path: workflows/overview.mdx
-            icon: fa-light fa-eye
-          - section: Examples
-            icon: fa-light fa-code
-            contents:
-              - page: Appointment scheduling
-                path: workflows/examples/appointment-scheduling.mdx
-                icon: fa-light fa-calendar-check
-              - page: Lead qualification
-                path: workflows/examples/lead-qualification.mdx
-                icon: fa-light fa-money-bill-wave
-              - page: Medical triage
-                path: workflows/examples/clinic-triage-scheduling.mdx
-                icon: fa-light fa-stethoscope
-              - page: Order management
-                path: workflows/examples/ecommerce-order-management.mdx
-                icon: fa-light fa-shopping-cart
-              - page: Property management
-                path: workflows/examples/property-management.mdx
-                icon: fa-light fa-building
-              - page: Multilingual support
-                path: workflows/examples/multilingual-support.mdx
-                icon: fa-light fa-globe
-
-      - section: Resources
-        collapsed: false
-        contents:
-          - page: FAQ
-            path: faq.mdx
-            icon: fa-light fa-question
-          - section: How Vapi works
-            icon: fa-light fa-diagram-project
-            contents:
-              - page: Core models
-                path: quickstart.mdx
-                icon: fa-light fa-microchip-ai
-              - page: Orchestration models
-                icon: fa-light fa-network-wired
-                path: how-vapi-works.mdx
-          - section: Integrations
-            collapsed: true
-            icon: fa-light fa-link
-            contents:
-              - section: Voices (Text-to-speech)
-                icon: fa-light fa-waveform-lines
-                contents:
-                  - section: Vapi Voices
-                    path: providers/voice/vapi-voices.mdx
-                    contents:
-                      - page: Legacy migration
-                        path: providers/voice/vapi-voices/legacy-migration.mdx
-                        icon: fa-light fa-triangle-exclamation
-                  - page: ElevenLabs
-                    path: providers/voice/elevenlabs.mdx
-                  - page: PlayHT
-                    path: providers/voice/playht.mdx
-                  - page: Azure
-                    path: providers/voice/azure.mdx
-                  - page: OpenAI
-                    path: providers/voice/openai.mdx
-                  - page: Cartesia
-                    path: providers/voice/cartesia.mdx
-                  - page: LMNT
-                    path: providers/voice/imnt.mdx
-                  - page: RimeAI
-                    path: providers/voice/rimeai.mdx
-                  - page: Deepgram
-                    path: providers/voice/deepgram.mdx
-                  - page: Inworld
-                    path: providers/voice/inworld.mdx
-
-              - section: Large language models
-                icon: fa-light fa-brain-circuit
-                contents:
-                  - page: OpenAI
-                    path: providers/model/openai.mdx
-                  - page: Azure OpenAI
-                    path: providers/model/azure-openai.mdx
-                  - page: Anthropic Bedrock
-                    path: providers/model/anthropic-bedrock.mdx
-                  - page: Gemini
-                    path: providers/model/gemini.mdx
-                  - page: Groq
-                    path: providers/model/groq.mdx
-                  - page: DeepInfra
-                    path: providers/model/deepinfra.mdx
-                  - page: Perplexity
-                    path: providers/model/perplexity.mdx
-                  - page: TogetherAI
-                    path: providers/model/togetherai.mdx
-                  - page: OpenRouter
-                    path: providers/model/openrouter.mdx
-
-              - section: Transcribers (Speech-to-text)
-                icon: fa-light fa-microphone
-                contents:
-                  - page: Deepgram
-                    path: providers/transcriber/deepgram.mdx
-                  - page: Google
-                    path: providers/transcriber/google.mdx
-                  - page: Gladia
-                    path: providers/transcriber/gladia.mdx
-                  - page: Speechmatics
-                    path: providers/transcriber/speechmatics.mdx
-                  - page: Talkscriber
-                    path: providers/transcriber/talkscriber.mdx
-                  - page: AssemblyAI
-                    path: providers/transcriber/assembly-ai.mdx
-
-              - section: Cloud storage
-                icon: fa-light fa-cloud-arrow-up
-                contents:
-                  - page: AWS S3
-                    path: providers/cloud/s3.mdx
-                    icon: fa-brands fa-aws
-                  - page: GCP Cloud Storage
-                    path: providers/cloud/gcp.mdx
-                    icon: fa-brands fa-google
-                  - page: Cloudflare R2
-                    path: providers/cloud/cloudflare.mdx
-                    icon: fa-brands fa-cloudflare
-                  - page: Supabase
-                    path: providers/cloud/supabase.mdx
-                    icon: fa-light fa-table
-              - section: Observability
-                icon: fa-light fa-magnifying-glass-chart
-                contents:
-                  - page: Langfuse
-                    path: providers/observability/langfuse.mdx
-              - section: Ecosystem
-                icon: fa-light fa-boxes-stacked
-                contents:
-                  - page: Voiceflow
-                    path: providers/voiceflow.mdx
-                  - page: ChatDash
-                    path: providers/chat-dash.mdx
-                  - page: Vapify
-                    path: providers/vapify.mdx
-                  - page: Voicerr AI
-                    path: providers/voicerr.mdx
-                  - page: VoiceAIWrapper
-                    path: providers/voiceaiwrapper.mdx
-                  - page: Sympana Connector
-                    path: providers/sympana-connector.mdx
-                    icon: fa-light fa-link
-
-          - section: Community
-            collapsed: true
-            icon: fa-light fa-users
-            contents:
-              - link: Videos
-                icon: fa-light fa-video
-                href: https://content.vapi.ai/
-              - link: Expert Directory
-                icon: fa-light fa-book-user
-                href: https://vapi.ai/library
-              - link: Discord
-                href: https://discord.com/invite/pUFNcf2WmH
-                icon: fa-brands fa-discord
-          - section: Support
-            icon: fa-light fa-circle-info
-            path: support.mdx
-            collapsed: true
-            contents:
-              - page: How to Report Issues
-                path: issue-reporting.mdx
-                icon: fa-light fa-bug
-              - page: Enterprise
-                path: enterprise/plans.mdx
-                icon: fa-light fa-building-shield
-              - page: Glossary
-                path: glossary.mdx
-                icon: fa-light fa-book-open
-              - page: RSS feed
-                path: rss-feed.mdx
-                icon: fa-light fa-rss
-          - section: Security and privacy
-            icon: fa-light fa-shield-check
-            collapsed: true
-            contents:
-              - page: Data flow
-                path: security-and-privacy/data-flow.mdx
-              - page: JWT authentication
-                path: customization/jwt-authentication.mdx
-              - page: Recording consent plan
-                path: security-and-privacy/recording-consent-plan.mdx
-              - page: GDPR compliance
-                path: security-and-privacy/GDPR.mdx
-              - page: HIPAA compliance
-                path: security-and-privacy/hipaa.mdx
-              - page: PCI compliance
-                path: security-and-privacy/PCI.mdx
-              - page: Proxy server guide
-                path: security-and-privacy/proxy-server.mdx
-              - page: Static IP addresses
-                path: security-and-privacy/static-ip-addresses.mdx
-              - link: SOC-2 Compliance
-                href: https://security.vapi.ai/
-          - section: Legal
-            collapsed: true
-            icon: fa-light fa-user-shield
-            contents:
-              - page: TCPA consent guidelines
-                path: tcpa-consent.mdx
-              - link: Privacy policy
-                href: https://vapi.ai/privacy
-              - link: Terms of service
-                href: https://vapi.ai/terms-of-service
-
-  - tab: api-reference
-    layout:
-      - api: API reference
-        api-name: api
-        flattened: true
-        skip-slug: true
-        paginated: true
-        snippets:
-          typescript: "@vapi/server-sdk"
-          python: vapi_server_sdk
-          go: https://github.com/VapiAI/server-sdk-go
-
-      - api: Webhooks
-        api-name: webhooks
-        paginated: true
-
-      - section: ""
-        contents:
-          - link: Swagger
-            href: https://api.vapi.ai/api
-          - link: OpenAPI
-            href: https://api.vapi.ai/api-json
-
-  - tab: mcp
-    layout:
-      - section: MCP
-        contents:
-          - page: MCP client
-            path: tools/mcp.mdx
-            icon: fa-light fa-network-wired
-          - page: MCP server
-            path: sdk/mcp-server.mdx
-            icon: fa-light fa-server
-
-  - tab: sdks
-    layout:
-      - section: Client SDKs
-        contents:
-          - link: Web SDK
-            href: https://github.com/VapiAI/web
-            icon: fa-brands fa-js
-          - link: iOS
-            href: https://github.com/VapiAI/ios
-            icon: fa-brands fa-apple
-          - link: Flutter
-            href: https://github.com/VapiAI/flutter
-            icon: fa-light fa-mobile
-          - link: React Native
-            href: https://github.com/VapiAI/react-native
-            icon: fa-brands fa-react
-          - link: Python
-            href: https://github.com/VapiAI/python
-            icon: fa-brands fa-python
-      - section: Server SDKs
-        contents:
-          - link: TypeScript
-            href: https://github.com/VapiAI/server-sdk-typescript
-            icon: fa-brands fa-js
-          - link: Python
-            href: https://github.com/VapiAI/server-sdk-python
-            icon: fa-brands fa-python
-          - link: Java
-            href: https://github.com/VapiAI/server-sdk-java
-            icon: fa-brands fa-java
-          - link: Ruby
-            href: https://github.com/VapiAI/server-sdk-ruby
-            icon: fa-light fa-gem
-          - link: C#
-            href: https://github.com/VapiAI/server-sdk-csharp
-            icon: fa-light fa-brackets-curly
-          - link: Go
-            href: https://github.com/VapiAI/server-sdk-go
-            icon: fa-brands fa-golang
-      - page: Ecosystem
-        path: resources.mdx
-        icon: fa-light fa-boxes-stacked
-
-  - tab: cli
+  - tab: docs
     layout:
       - section: Getting Started
         contents:
+          - page: Introduction
+            path: ./docs/pages/introduction.mdx
+            slug: introduction
+          - page: Quickstart
+            path: ./docs/pages/quickstart.mdx
+            slug: quickstart
+          - page: Dashboard
+            path: ./docs/pages/dashboard.mdx
+            slug: dashboard
+          - page: Glossary
+            path: ./docs/pages/glossary.mdx
+            slug: glossary
+          - page: Examples
+            path: ./docs/pages/examples.mdx
+            slug: examples
+      - section: Assistants
+        contents:
+          - page: Assistants
+            path: ./docs/pages/assistants/assistants.mdx
+            slug: assistants
+          - page: Tools (Function Calling)
+            path: ./docs/pages/assistants/function_calling.mdx
+            slug: tools
+          - page: Squads
+            path: ./docs/pages/assistants/squads.mdx
+            slug: squads
+          - page: Background Messages
+            path: ./docs/pages/assistants/background-messages.mdx
+            slug: assistants/background-messages
+          - page: Dynamic Data
+            path: ./docs/pages/assistants/dynamic-data.mdx
+            slug: assistants/dynamic-data
+          - page: Multilingual Support
+            path: ./docs/pages/assistants/multilingual.mdx
+            slug: multilingual
+          - section: Text-based Conversations
+            slug: text-based-conversations
+            contents:
+              - page: Overview
+                path: ./docs/pages/assistants/text/overview.mdx
+                slug: text-based-conversations
+              - page: Chat Widget
+                path: ./docs/pages/assistants/text/chat-widget.mdx
+                slug: text-based-conversations/chat-widget
+              - page: SMS
+                path: ./docs/pages/assistants/text/sms.mdx
+                slug: text-based-conversations/sms
+              - page: Custom Channel (API)
+                path: ./docs/pages/assistants/text/custom.mdx
+                slug: text-based-conversations/custom-channel
+      - section: Calls
+        contents:
+          - page: Outbound Calls
+            path: ./docs/pages/calls/outbound-calls.mdx
+            slug: calls/outbound-calls
+          - page: Call Ended Reason
+            path: ./docs/pages/calls/call-ended-reason.mdx
+            slug: call-ended-reason
+          - page: Call Functions
+            path: ./docs/pages/calls/call-functions.mdx
+            slug: call-functions
+          - page: Call Forwarding
+            path: ./docs/pages/calls/call-forwarding.mdx
+            slug: call-forwarding
+          - page: Call Hooks
+            path: ./docs/pages/calls/call-hooks.mdx
+            slug: call-hooks
+          - section: Batch Calling
+            slug: batch-calling
+            contents:
+              - page: Overview
+                path: ./docs/pages/calls/batch-calling/batch-calling.mdx
+                slug: batch-calling
+              - page: Quick Start
+                path: ./docs/pages/calls/batch-calling/quick-start.mdx
+                slug: batch-calling/quick-start
+              - page: Batch Calling with Vapi SDKs
+                path: ./docs/pages/calls/batch-calling/using-sdks.mdx
+                slug: batch-calling/using-sdks
+      - section: Phone Numbers
+        contents:
+          - page: Importing Numbers
+            path: ./docs/pages/phone-numbers/import.mdx
+            slug: phone-numbers
+          - page: Custom Twilio Accounts
+            path: ./docs/pages/phone-numbers/custom-twilio.mdx
+            slug: custom-twilio
+          - page: BYOSIP
+            path: ./docs/pages/phone-numbers/byosip.mdx
+            slug: byosip
+          - page: Free Test Number
+            path: ./docs/pages/phone-numbers/free-test-number.mdx
+            slug: free-test-number
+      - section: Billing
+        slug: billing
+        contents:
+          - page: Billing
+            path: ./docs/pages/billing/billing.mdx
+            slug: billing
+          - page: Cost Routing
+            path: ./docs/pages/billing/cost-routing.mdx
+            slug: billing/cost-routing
+          - page: Estimating Costs
+            path: ./docs/pages/billing/estimating-costs.mdx
+            slug: billing/estimating-costs
+          - page: Billing Limits
+            path: ./docs/pages/billing/billing-limits.mdx
+            slug: billing/billing-limits
+      - section: AI Models
+        contents:
+          - page: Using Custom LLMs
+            path: ./docs/pages/customization/custom-llm.mdx
+            slug: customization/custom-llm
+          - page: Using Custom Voices
+            path: ./docs/pages/customization/custom-voices.mdx
+            slug: customization/custom-voices
+          - page: OpenAI Realtime
+            path: ./docs/pages/customization/openai-realtime.mdx
+            slug: openai-realtime
+          - page: Google Gemini Live
+            path: ./docs/pages/customization/google-gemini-live.mdx
+            slug: google-gemini-live
+          - page: Cerebras
+            path: ./docs/pages/customization/cerebras.mdx
+            slug: cerebras
+          - page: Fine-Tuned Models
+            path: ./docs/pages/customization/fine-tuned-models.mdx
+            slug: fine-tuned-models
+      - section: Knowledgebase
+        slug: knowledgebase
+        contents:
+          - page: Knowledgebase
+            path: ./docs/pages/knowledgebase/knowledgebase.mdx
+            slug: knowledgebase
+          - page: Integrations
+            path: ./docs/pages/knowledgebase/integrations.mdx
+            slug: knowledgebase/integrations
+      - section: Workflows
+        slug: workflows
+        contents:
           - page: Overview
-            path: cli/overview.mdx
-            icon: fa-light fa-rocket
-      - section: Core Features
+            path: ./docs/pages/workflows/overview.mdx
+            slug: workflows
+          - page: Introduction
+            path: ./docs/pages/workflows/introduction.mdx
+            slug: workflows/introduction
+          - page: Steps
+            path: ./docs/pages/workflows/steps.mdx
+            slug: workflows/steps
+          - page: Variables
+            path: ./docs/pages/workflows/variables.mdx
+            slug: workflows/variables
+          - page: Edges and Conditions
+            path: ./docs/pages/workflows/edges.mdx
+            slug: workflows/edges
+          - page: Templates
+            path: ./docs/pages/workflows/templates.mdx
+            slug: workflows/templates
+          - page: Versioning
+            path: ./docs/pages/workflows/versioning.mdx
+            slug: workflows/versioning
+          - page: Global Nodes
+            path: ./docs/pages/workflows/global-nodes.mdx
+            slug: workflows/global-nodes
+          - page: Cookbook
+            path: ./docs/pages/workflows/cookbook.mdx
+            slug: workflows/cookbook
+      - section: Observability
+        slug: observability
         contents:
-          - page: Project Integration
-            path: cli/project-integration.mdx
-            icon: fa-light fa-folder-plus
-          - page: MCP Integration
-            path: cli/mcp-integration.mdx
-            icon: fa-light fa-brain-circuit
-          - page: Webhook Testing
-            path: cli/webhook-testing.mdx
-            icon: fa-light fa-webhook
-          - page: Authentication
-            path: cli/authentication.mdx
-            icon: fa-light fa-key
-      - section: Resources
+          - page: Dashboard Observability
+            path: ./docs/pages/observability/dashboard.mdx
+            slug: observability/dashboard
+          - page: Logging
+            path: ./docs/pages/observability/logging.mdx
+            slug: observability/logging
+          - page: Analytics
+            path: ./docs/pages/observability/analytics.mdx
+            slug: observability/analytics
+      - section: Evaluation & Testing
+        slug: evals
         contents:
-          - link: GitHub Repository
-            href: https://github.com/VapiAI/cli
-            icon: fa-brands fa-github
-          - link: Report Issues
-            href: https://github.com/VapiAI/cli/issues
-            icon: fa-light fa-bug
-
+          - page: Overview
+            path: ./docs/pages/evals/overview.mdx
+            slug: evals
+          - page: Running Tests
+            path: ./docs/pages/evals/running.mdx
+            slug: evals/running
+          - page: Scorers
+            path: ./docs/pages/evals/scorers.mdx
+            slug: evals/scorers
+      - section: Privacy & Security
+        contents:
+          - page: HIPAA
+            path: ./docs/pages/enterprise/hipaa.mdx
+            slug: hipaa
+          - page: PII & PHI Handling
+            path: ./docs/pages/enterprise/pii-phi-handling.mdx
+            slug: pii-phi-handling
+          - page: Data Retention
+            path: ./docs/pages/enterprise/data-retention.mdx
+            slug: data-retention
+      - section: Guides & Tutorials
+        slug: guides
+        contents:
+          - page: Voice Widget
+            path: ./docs/pages/clients/voice-widget.mdx
+            slug: voice-widget
+          - page: Client SDKs
+            path: ./docs/pages/clients/client-sdks.mdx
+            slug: clients
+          - page: Server SDKs
+            path: ./docs/pages/SDKs/server-sdks.mdx
+            slug: server-sdks
+          - page: Server Events
+            path: ./docs/pages/server-url.mdx
+            slug: server-url
+          - page: Prompting Guide
+            path: ./docs/pages/assistants/prompting.mdx
+            slug: prompting-guide
+          - page: Persistent Calls
+            path: ./docs/pages/calls/persistent-calls.mdx
+            slug: persistent-calls
+          - page: Multi-User Calls
+            path: ./docs/pages/calls/multi-user-calls.mdx
+            slug: multi-user-calls
+          - page: Voicemail Detection
+            path: ./docs/pages/calls/voicemail-detection.mdx
+            slug: voicemail-detection
+          - page: GHL Integration
+            path: ./docs/pages/GHL.mdx
+            slug: GHL
+          - page: Synthflow Migration Guide
+            path: ./docs/pages/guides/synthflow-migration.mdx
+            slug: guides/synthflow-migration
+  - tab: api-reference
+    layout:
+      - section: API Reference
+        contents:
+          - page: Introduction
+            path: ./docs/pages/api-reference/introduction.mdx
+            slug: api-reference
+      - api: API Reference
+        api-name: api
+        audiences:
+          - external
+        snippets:
+          python: vapi_server_sdk
+          node: "@vapi-ai/server-sdk"
+        layout:
+          - call:
+              - endpoint: POST /call
+              - endpoint: GET /call/{id}
+              - endpoint: PATCH /call/{id}
+              - endpoint: DELETE /call/{id}
+              - endpoint: GET /call
+          - assistant:
+              - endpoint: POST /assistant
+              - endpoint: GET /assistant/{id}
+              - endpoint: PATCH /assistant/{id}
+              - endpoint: DELETE /assistant/{id}
+              - endpoint: GET /assistant
+          - phone-number:
+              - endpoint: POST /phone-number
+              - endpoint: GET /phone-number/{id}
+              - endpoint: PATCH /phone-number/{id}
+              - endpoint: DELETE /phone-number/{id}
+              - endpoint: GET /phone-number
+          - tool:
+              - endpoint: POST /tool
+              - endpoint: GET /tool/{id}
+              - endpoint: PATCH /tool/{id}
+              - endpoint: DELETE /tool/{id}
+              - endpoint: GET /tool
+          - knowledge-base:
+              - endpoint: POST /knowledge-base
+              - endpoint: GET /knowledge-base/{id}
+              - endpoint: PATCH /knowledge-base/{id}
+              - endpoint: DELETE /knowledge-base/{id}
+              - endpoint: GET /knowledge-base
+          - file:
+              - endpoint: POST /file
+              - endpoint: GET /file/{id}
+              - endpoint: PATCH /file/{id}
+              - endpoint: DELETE /file/{id}
+              - endpoint: GET /file
+          - workflow:
+              - endpoint: POST /workflow
+              - endpoint: GET /workflow/{id}
+              - endpoint: PATCH /workflow/{id}
+              - endpoint: DELETE /workflow/{id}
+              - endpoint: GET /workflow
+          - squad:
+              - endpoint: POST /squad
+              - endpoint: GET /squad/{id}
+              - endpoint: PATCH /squad/{id}
+              - endpoint: DELETE /squad/{id}
+              - endpoint: GET /squad
+          - test-suite:
+              - endpoint: POST /test-suite
+              - endpoint: GET /test-suite/{id}
+              - endpoint: PATCH /test-suite/{id}
+              - endpoint: DELETE /test-suite/{id}
+              - endpoint: GET /test-suite
+          - test-suite-run:
+              - endpoint: POST /test-suite/{testSuiteId}/run
+              - endpoint: GET /test-suite/{testSuiteId}/run/{id}
+              - endpoint: PATCH /test-suite/{testSuiteId}/run/{id}
+              - endpoint: DELETE /test-suite/{testSuiteId}/run/{id}
+              - endpoint: GET /test-suite/{testSuiteId}/run
+          - test-suite-test:
+              - endpoint: POST /test-suite/{testSuiteId}/test
+              - endpoint: GET /test-suite/{testSuiteId}/test/{id}
+              - endpoint: PATCH /test-suite/{testSuiteId}/test/{id}
+              - endpoint: DELETE /test-suite/{testSuiteId}/test/{id}
+              - endpoint: GET /test-suite/{testSuiteId}/test
+          - token:
+              - endpoint: POST /token
+          - log:
+              - endpoint: GET /log
+          - analytics:
+              - endpoint: POST /analytics
+          - webhook-credential:
+              - endpoint: POST /credential/webhook
+  - tab: sdks
+    layout:
+      - section: SDKs
+        contents:
+          - page: Overview
+            path: ./docs/pages/SDKs/sdks-overview.mdx
+            slug: sdks
+      - section: Client SDKs
+        slug: sdks/client
+        contents:
+          - page: Web
+            slug: sdks/web
+            path: ./docs/pages/SDKs/web.mdx
+          - page: Python
+            slug: sdks/python
+            path: ./docs/pages/SDKs/python.mdx
+          - page: iOS (Swift)
+            slug: sdks/ios
+            path: ./docs/pages/SDKs/swift.mdx
+          - page: Android (Kotlin)
+            slug: sdks/android
+            path: ./docs/pages/SDKs/kotlin.mdx
+          - page: Flutter
+            slug: sdks/flutter
+            path: ./docs/pages/SDKs/flutter.mdx
+          - page: React Native
+            slug: sdks/react-native
+            path: ./docs/pages/SDKs/react-native.mdx
+          - page: Java
+            slug: sdks/java
+            path: ./docs/pages/SDKs/java.mdx
+          - page: .NET (C#)
+            slug: sdks/C-sharp
+            path: ./docs/pages/SDKs/C-sharp.mdx
+      - section: Server SDKs
+        slug: sdks/server
+        contents:
+          - page: Python
+            slug: sdks/server/python
+            path: ./docs/pages/SDKs/server-python.mdx
+          - page: Node.js
+            slug: sdks/server/node
+            path: ./docs/pages/SDKs/server-node.mdx
+          - page: Ruby
+            slug: sdks/server/ruby
+            path: ./docs/pages/SDKs/server-ruby.mdx
+          - page: Go
+            slug: sdks/server/go
+            path: ./docs/pages/SDKs/server-go.mdx
   - tab: changelog
+
+css: ./docs/static/styles.css
+js:
+  - path: ./docs/static/scripts/fern.js
+    strategy: lazyOnload
 
 redirects:
   - source: /developer-documentation
     destination: /introduction
   - source: /documentation/general/changelog
-    destination: /changelog
+    destination: /whats-new
+  - source: /changelog
+    destination: /whats-new
   - source: /api-reference/assistants/create-assistant
     destination: /api-reference/assistants/create
   - source: /api-reference/assistants/get-assistant
     destination: /api-reference/assistants/get
-  - source: /api-reference/assistants/list-assistants
-    destination: /api-reference/assistants/list
   - source: /api-reference/assistants/update-assistant
     destination: /api-reference/assistants/update
   - source: /api-reference/assistants/delete-assistant
     destination: /api-reference/assistants/delete
-  - source: /api-reference/calls/create-call
-    destination: /api-reference/calls/create
+  - source: /api-reference/assistants/list-assistants
+    destination: /api-reference/assistants/list
   - source: /api-reference/calls/create-phone-call
     destination: /api-reference/calls/create
   - source: /api-reference/calls/get-call
     destination: /api-reference/calls/get
-  - source: /api-reference/calls/list-calls
-    destination: /api-reference/calls/list
   - source: /api-reference/calls/update-call
     destination: /api-reference/calls/update
   - source: /api-reference/calls/delete-call-data
     destination: /api-reference/calls/delete
-  - source: /api-reference/phone-numbers/create-phone-number
+  - source: /api-reference/calls/list-calls
+    destination: /api-reference/calls/list
+  - source: /api-reference/phone-numbers/buy-phone-number
     destination: /api-reference/phone-numbers/create
   - source: /api-reference/phone-numbers/get-phone-number
     destination: /api-reference/phone-numbers/get
-  - source: /api-reference/phone-numbers/list-phone-numbers
-    destination: /api-reference/phone-numbers/list
   - source: /api-reference/phone-numbers/update-phone-number
     destination: /api-reference/phone-numbers/update
   - source: /api-reference/phone-numbers/delete-phone-number
     destination: /api-reference/phone-numbers/delete
-  - source: /api-reference/files/upload-file
-    destination: /api-reference/files/upload
-  - source: /api-reference/files/get-file
-    destination: /api-reference/files/get
-  - source: /api-reference/files/list-files
-    destination: /api-reference/files/list
-  - source: /api-reference/files/update-file
-    destination: /api-reference/files/update
-  - source: /api-reference/files/delete-file
-    destination: /api-reference/files/delete
+  - source: /api-reference/phone-numbers/list-phone-numbers
+    destination: /api-reference/phone-numbers/list
   - source: /api-reference/squads/create-squad
     destination: /api-reference/squads/create
   - source: /api-reference/squads/get-squad
     destination: /api-reference/squads/get
-  - source: /api-reference/squads/list-squads
-    destination: /api-reference/squads/list
   - source: /api-reference/squads/update-squad
     destination: /api-reference/squads/update
   - source: /api-reference/squads/delete-squad
     destination: /api-reference/squads/delete
+  - source: /api-reference/squads/list-squads
+    destination: /api-reference/squads/list
   - source: /api-reference/tools/create-tool
     destination: /api-reference/tools/create
   - source: /api-reference/tools/get-tool
     destination: /api-reference/tools/get
-  - source: /api-reference/tools/list-tools
-    destination: /api-reference/tools/list
   - source: /api-reference/tools/update-tool
     destination: /api-reference/tools/update
   - source: /api-reference/tools/delete-tool
     destination: /api-reference/tools/delete
-  - source: /api-reference/analytics/create-analytics-queries
-    destination: /api-reference/analytics/get
-  - source: /api-reference/messages/server-message
-    destination: /api-reference/webhooks/server-message
-  - source: /api-reference/messages/server-message-response
-    destination: /api-reference/webhooks/server-message
-  - source: /api-reference/messages/client-message
-    destination: /api-reference/webhooks/client-message
-  - source: /api-reference/messages/client-inbound-message
-    destination: /api-reference/webhooks/client-message
-  - source: "/api-reference/phone-numbers/import-twilio-number"
-    destination: "/api-reference/phone-numbers/create-phone-number"
-  - source: /community/expert-directory
-    destination: https://vapi.ai/library
-  - source: "api-reference/calls/create-call"
-    destination: "https://api.vapi.ai/api#/Calls/CallController_create"
-  - source: "/getting_started"
-    destination: "/quickstart/phone"
-  - source: "/dashboard"
-    destination: "/quickstart/phone"
-  - source: "/quickstart/dashboard"
-    destination: "/quickstart/phone"
-  - source: "/provider_keys"
-    destination: "/assistants/provider-keys"
-  - source: "/provider-keys"
-    destination: "/assistants/provider-keys"
-  - source: "/custom_llm"
-    destination: "/assistants/custom-llm"
-  - source: "/custom-llm"
-    destination: "/assistants/custom-llm"
-  - source: "/custom_voice"
-    destination: "/assistants/custom-voice"
-  - source: "/custom-voice"
-    destination: "/assistants/custom-voice"
-  - source: "/function_calling"
-    destination: "/assistants/function-calling"
-  - source: "/function-calling"
-    destination: "/assistants/function-calling"
-  - source: "/persistent_assistants"
-    destination: "/assistants/persistent-assistants"
-  - source: "/persistent-assistants"
-    destination: "/assistants/persistent-assistants"
-  - source: "/dynamic_variables"
-    destination: "/assistants/dynamic-variables"
-  - source: "/dynamic-variables"
-    destination: "/assistants/dynamic-variables"
-  - source: "/call_analysis"
-    destination: "/assistants/call-analysis"
-  - source: "/call-analysis"
-    destination: "/assistants/call-analysis"
-  - source: "/text_message"
-    destination: "/assistants/background-messages"
-  - source: "/text-message"
-    destination: "/assistants/background-messages"
-  - source: "/privacy_hipaa"
-    destination: "/enterprise/hipaa"
-  - source: "/server_url"
-    destination: "/server-url"
-  - source: "/phone_calling"
-    destination: "/phone-calling"
-  - source: "/multilingual_support"
-    destination: "/multilingual"
-  - source: "/multilingual/introduction"
-    destination: "/multilingual"
-  - source: "/outbound_sales"
-    destination: "/workflows/examples/lead-qualification"
-  - source: "/technical_support"
-    destination: "/assistants/examples/inbound-support"
-  - source: "/pizza_website"
-    destination: "/assistants/examples/inbound-support"
-  - source: "/examples/pizza-website"
-    destination: "/assistants/examples/inbound-support"
-  - source: "/voice_widget"
-    destination: "/assistants/examples/voice-widget"
-  - source: "/clients"
-    destination: "/sdks"
-  - source: "/error_message_guide"
-    destination: "/calls/call-ended-reason"
-  - source: "/privacy"
-    destination: "/privacy-policy"
-  - source: "/call_forwarding"
-    destination: "/call-forwarding"
-  - source: "/prompting_guide"
-    destination: "/prompting-guide"
-  - source: "/community/videos"
-    destination: "/community/appointment-scheduling"
-  - source: "/enterprise"
-    destination: "/enterprise/plans"
-  - source: "/tools-calling"
-    destination: "/assistants/custom-tools"
-  - source: "/knowledgebase"
-    destination: "/knowledge-base"
-  - source: "/quickstart/billing"
-    destination: "/billing/billing-faq"
-  - source: /assistants/default-tools
-    destination: /tools/default-tools
-  - source: /assistants/function-calling
-    destination: /tools/default-tools
-  - source: /assistants/custom-tools
-    destination: /tools/custom-tools
-  - source: /GHL
-    destination: /tools/GHL
-  - source: /phone-calling/voice-mail-detection
-    destination: /calls/voicemail-detection
-  - source: /phone-calling/voicemail-detection
-    destination: /calls/voicemail-detection
+  - source: /api-reference/tools/list-tools
+    destination: /api-reference/tools/list
+  - source: /api-reference/files/upload-file
+    destination: /api-reference/files/create
+  - source: /api-reference/files/get-file
+    destination: /api-reference/files/get
+  - source: /api-reference/files/update-file
+    destination: /api-reference/files/update
+  - source: /api-reference/files/delete-file
+    destination: /api-reference/files/delete
+  - source: /api-reference/files/list-files
+    destination: /api-reference/files/list
+  - source: /api-reference/knowledge-bases/create-knowledge-base
+    destination: /api-reference/knowledge-bases/create
+  - source: /api-reference/knowledge-bases/get-knowledge-base
+    destination: /api-reference/knowledge-bases/get
+  - source: /api-reference/knowledge-bases/update-knowledge-base
+    destination: /api-reference/knowledge-bases/update
+  - source: /api-reference/knowledge-bases/delete-knowledge-base
+    destination: /api-reference/knowledge-bases/delete
+  - source: /api-reference/knowledge-bases/list-knowledge-bases
+    destination: /api-reference/knowledge-bases/list
   - source: /quickstart/phone/inbound
-    destination: /quickstart/phone
+    destination: /quickstart
   - source: /quickstart/phone/outbound
-    destination: /quickstart/phone
-  - source: /introduction
     destination: /quickstart
-  - source: /welcome
-    destination: /quickstart/introduction
-  - source: /sdks
-    destination: /sdk/web
-  - source: /server-sdks
-    destination: /sdk/web
-  - source: /overview
+  - source: /quickstart/dashboard
     destination: /quickstart
-  - source: /assistants
-    destination: /assistants/quickstart
-  - source: /examples/outbound-sales
-    destination: /workflows/examples/lead-qualification
-  - source: /workflows
-    destination: /workflows/quickstart
-  - source: /web-integration
-    destination: /web
-  - source: /examples/inbound-support
-    destination: /assistants/examples/inbound-support
-  - source: /examples/voice-widget
-    destination: /assistants/examples/voice-widget
-  - source: /examples/docs-agent
-    destination: /assistants/examples/docs-agent
-  - source: /sdk/web
-    destination: /quickstart/web
-  - source: /workflows/examples
-    destination: /workflows/examples/appointment-scheduling
-  - source: /assistants/examples
-    destination: /assistants/examples/inbound-support
-  - source: /examples
-    destination: /guides
-  - source: /quickstart/web-integration
-    destination: /quickstart/web
-  - source: /assistants/speech-configuration
-    destination: /customization/speech-configuration
-  - source: /assistants/tools
-    destination: /tools
-  - source: /assistants/knowledge-base
-    destination: /knowledge-base/knowledge-base
-  - source: /assistants/tools/google-calendar
-    destination: /tools/google-calendar
-  - source: /assistants/tools/slack
-    destination: /tools/slack
-  - source: /assistants/tools/google-sheets
-    destination: /tools/google-sheets
-  - source: /assistants/workflows
-    destination: /workflows/quickstart
-  - source: /tools/GHL
-    destination: /tools/go-high-level
-  - source: /challenges-of-realtime-conversation
-    destination: /quickstart/introduction
-  - source: /advanced/sip-trunk.mdx
-    destination: /advanced/sip
-  - source: /quickstart/import-twillio
-    destination: /phone-numbers/import-twilio
-  - source: /phone-numbers/import-twillio
-    destination: /phone-numbers/import-twilio
-  # Additional 404 redirects to relevant content
-  - source: /phone-calling/outbound-calls
-    destination: /calls/outbound-calling
-  - source: /docs/api/workflows
-    destination: /workflows/quickstart
-  - source: /docs/workflows
-    destination: /workflows/quickstart
-  - source: /docs/transcription
-    destination: /customization/custom-transcriber
-  - source: /docs/assistants
-    destination: /assistants/quickstart
-  - source: /assistants/overview
-    destination: /assistants/quickstart
-  - source: /docs/tools
-    destination: /tools
-  - source: /docs/squads
+  - source: /quickstart/web
+    destination: /quickstart
+  - source: /getting_started
+    destination: /quickstart
+  - source: /technical-reference/phone-calling
+    destination: /calls/outbound-calls
+  - source: /server_url
+    destination: /server-url
+  - source: /how_vapi_works
+    destination: /introduction
+  - source: /out-of-band-authentication
+    destination: /server-url
+  - source: /outbound_sales
+    destination: /examples
+  - source: /pizza_website
+    destination: /examples
+  - source: /technical-reference/sip
+    destination: /byosip
+  - source: /community
+    destination: /introduction
+  - source: /privacy
+    destination: /hipaa
+  - source: /multi-prompt-assistant
     destination: /squads
-  - source: /assets/batch-sample.csv
-    destination: /workflows/examples/lead-qualification
-  - source: /fern/api-reference
-    destination: /api-reference/calls/list
-  - source: /documentation/chat/chat
-    destination: /api-reference/chats
+  - source: /calls/call_features
+    destination: /call-functions
+  - source: /assistants/function-calling
+    destination: /tools
+  - source: /assistants/custom-voice
+    destination: /customization/custom-voices
+  - source: /customization/custom-keywords
+    destination: /assistants
+  - source: /customization/provider-keys
+    destination: /dashboard
+  - source: /phone_calling
+    destination: /calls/outbound-calls
+  - source: /assistants/persistent-assistants
+    destination: /assistants
+  - source: /assistants/provider-keys
+    destination: /dashboard
+  - source: /assistants/custom-llm
+    destination: /customization/custom-llm
+  - source: /assistants/custom-transcriber
+    destination: /customization/custom-llm
+  - source: /clients/web
+    destination: /voice-widget
+  - source: /clients/ios
+    destination: /sdks/ios
+  - source: /clients/android
+    destination: /sdks/android
+  - source: /clients/flutter
+    destination: /sdks/flutter
+  - source: /clients/react-native
+    destination: /sdks/react-native
+  - source: /clients/python
+    destination: /sdks/python
+  - source: /SDKs/web
+    destination: /voice-widget
+  - source: /SDKs/ios
+    destination: /sdks/ios
+  - source: /SDKs/android
+    destination: /sdks/android
+  - source: /SDKs/flutter
+    destination: /sdks/flutter
+  - source: /SDKs/react-native
+    destination: /sdks/react-native
+  - source: /SDKs/python
+    destination: /sdks/python


### PR DESCRIPTION
## Description
<!-- describe the changes as bullet points -->
- Renamed tab display name from "Changelog" to "What's New" in `fern/docs.yml`
- Updated tab slug from `changelog` to `whats-new` in `fern/docs.yml`
- Updated existing redirect for `/documentation/general/changelog` to point to `/whats-new` in `fern/docs.yml`
- Added new redirect from `/changelog` to `/whats-new` in `fern/docs.yml`
- Updated frontmatter slug from `changelog` to `whats-new` in `fern/changelog/overview.mdx`
- Updated subscription text from "Get the (almost) daily changelog" to "Subscribe to the latest product updates" in `fern/changelog/overview.mdx`
- Updated Customer.io form success URL to `https://docs.vapi.ai/whats-new` in `fern/changelog/overview.mdx`

## Testing Steps
- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
- [ ] Verify `/whats-new` URL loads the renamed page
- [ ] Verify `/changelog` redirects to `/whats-new`
- [ ] Verify subscription form success URL points to `/whats-new`
