### PR TITLE
Add deprecation banner to Test Suites page

### DIFF
--- a/fern/test/test-suites.mdx
+++ b/fern/test/test-suites.mdx
@@ -4,6 +4,10 @@ subtitle: End-to-end test automation for AI voice agents
 slug: /test/test-suites
 ---
 
+<Warning>
+Test Suites is being deprecated. It will be replaced by Simulations, a more powerful way to test your voice agents. You can keep using Test Suites in the meantime, and we'll share a migration guide once Simulations is ready.
+</Warning>
+
 ## Overview
 
 **Test Suite** is an end-to-end feature that automates testing of your AI voice agents. Our platform simulates an AI tester that interacts with your voice agent by following a pre-defined script. After the interaction, the transcript is sent to a language model (LLM) along with your evaluation rubric. The LLM then determines if the interaction met the defined objectives.


### PR DESCRIPTION
## Description
<!-- describe the changes as bullet points -->
- Add a `<Warning>` deprecation banner to the Test Suites documentation page (`fern/test/test-suites.mdx`)
- The banner informs users that Test Suites is being deprecated and will be replaced by Simulations
- Uses the same `<Warning>` component pattern already established in `fern/tools/default-tools.mdx`

Resolves DEVREL-617

## Testing Steps
- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
- [ ] Verify the deprecation warning banner renders correctly at the top of the Test Suites page