### PR TITLE
fix: add subscriptionLimits to Call schema in OpenAPI spec

### DIFF
--- a/fern/apis/api/openapi.json
+++ b/fern/apis/api/openapi.json
@@ -34766,6 +34766,14 @@
           "transport": {
             "type": "object",
             "description": "This is the transport of the call."
+          },
+          "subscriptionLimits": {
+            "description": "These are the subscription limits for the org at the time of the call. Includes concurrency limit information.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SubscriptionLimits"
+              }
+            ]
           }
         },
         "required": [


### PR DESCRIPTION
## Description

- Add `subscriptionLimits` property to the `Call` schema in `openapi.json`
- The `SubscriptionLimits` schema already exists and is referenced by `CallBatchResponse`, but was missing from the `Call` schema
- The live API (`POST /call`) returns `subscriptionLimits` in the response, and this is documented in `fern/calls/call-concurrency.mdx`, but the OpenAPI spec `Call` schema did not include it
- This causes all auto-generated SDKs (C#, Python, TypeScript, etc.) to be missing the `subscriptionLimits` field on the Call object
- Once merged and SDKs are regenerated, the field will be available in all Vapi SDKs

Fixes PRO-1773

## Testing Steps

- [x] Run `fern check` -- passes with 0 errors (5 pre-existing warnings unrelated to this change)
- [x] Validated JSON syntax is correct
- [x] Verified `$ref` points to existing `SubscriptionLimits` schema (with `concurrencyBlocked`, `concurrencyLimit`, `remainingConcurrentCalls` properties)
- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work