### PR TITLE
Add changelog entries for weeks of April 13, 20 & 27, 2026

### DIFF
--- a/fern/changelog/2026-04-13.mdx
+++ b/fern/changelog/2026-04-13.mdx
@@ -1,0 +1,6 @@
+# What's New: Week of April 13, 2026
+
+1. **Monitoring — GA**: Automated call quality monitoring is now generally available. Detect issues with trigger-based rules, get alerts when something goes wrong, and surface resolution suggestions — all from the dashboard.
+
+    - [Monitoring quickstart](https://docs.vapi.ai/observability/monitoring-quickstart)
+    - [Announcement blog post](https://blog.vapi.ai/monitoring)

--- a/fern/changelog/2026-04-20.mdx
+++ b/fern/changelog/2026-04-20.mdx
@@ -1,0 +1,14 @@
+# What's New: Week of April 20, 2026
+
+1. **Logs UX Refresh**: New filter layout plus a round of UX improvements — improved date picker, active row is clearly highlighted across all log views when the flyout is opened, log tables are fully keyboard-accessible, sortable `cost` and `duration` columns, pagination, and more.
+
+2. **Squads `contextEngineeringPlan` Handoff Type — `previousAssistantMessages`**: Forwards only the conversation history from *before* the current assistant's session. The current assistant's own messages and tool calls are excluded entirely from the handoff payload. See the updated [handoff context configuration docs](https://docs.vapi.ai/security-and-privacy/pci#handoff-context-configuration).
+
+3. **`assistant.speechStarted` Event — Live Captions & Word-Level Timing (GA)**: A new opt-in message fires as the assistant begins speaking each segment, carrying the full turn text, `turn`, `source` (`model` / `force-say` / `custom-voice`), and optional timing:
+    - Per-word alignment on **ElevenLabs**
+    - Cursor-based word-progress on **Minimax** (set `voice.subtitleType: "word"`, with correct CJK handling)
+    - Text-only fallback on all other providers
+
+    Subscribe by adding `"assistant.speechStarted"` to your assistant's `clientMessages` and/or `serverMessages` — now **GA with no feature flag**. Use it for live captions, karaoke-style highlighting, or any UI that needs to stay in sync with assistant audio. Fully backward-compatible; no existing messages changed.
+
+4. **Autofallbacks on Transcribers**: Let Vapi pick the best transcriber to fall back to if your primary one fails — even mid-call. Opt in by setting `assistant.transcriber.fallbackPlan.autoFallback.enabled` to `true`. See the updated [transcriber fallback plan docs](https://docs.vapi.ai/customization/transcriber-fallback-plan).


### PR DESCRIPTION
## Description

Adds three new changelog entries under `fern/changelog/`, rendering in reverse-chronological order (April 27 on top, then April 20, then April 13, above the existing Oct 2025 – March 2026 summary).

### Week of April 27, 2026 (`2026-04-27.mdx`)
- **Deepgram Flux — Multilingual Support** — multilingual agents can now leverage the same smart turn-taking that powers the English Flux transcriber

### Week of April 20, 2026 (`2026-04-20.mdx`)
- **Logs UX Refresh** — new filter layout, improved date picker, highlighted active row on all log views, keyboard-accessible tables, sortable `cost`/`duration` columns, pagination
- **Squads `contextEngineeringPlan` handoff type `previousAssistantMessages`** — forwards only pre-session history, excluding the current assistant's messages and tool calls (links to the PCI handoff context configuration docs)
- **`assistant.speechStarted` event — GA** — opt-in event with full turn text, `turn`, `source`, and optional timing; per-word alignment on ElevenLabs, cursor-based word-progress on Minimax (incl. CJK), text-only fallback elsewhere; fully backward-compatible
- **Autofallbacks on transcribers** — opt in via `assistant.transcriber.fallbackPlan.autoFallback.enabled = true` (links to the updated fallback plan docs)

### Week of April 13, 2026 (`2026-04-13.mdx`)
- **Monitoring — GA** — automated call quality monitoring with trigger-based rules, alerts, and resolution suggestions; links to the [monitoring quickstart](https://docs.vapi.ai/observability/monitoring-quickstart) and [announcement blog post](https://blog.vapi.ai/monitoring)

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Verify all three changelog entries render correctly on `/whats-new` and appear in the expected order (April 27 → April 20 → April 13)
- [ ] Confirm all documentation and blog links resolve

https://claude.ai/code/session_01LZKc1zrMXuAC3GXiGc4Gin