### PR TITLE
docs(squads): add icon to 'Passing data between assistants' nav entry

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -343,6 +343,7 @@ navigation:
             icon: fa-light fa-hand-holding-hand
           - page: Passing data between assistants
             path: squads/passing-data-between-assistants.mdx
+            icon: fa-light fa-share-nodes
           - section: Examples
             icon: fa-light fa-code
             contents:


### PR DESCRIPTION
Adds `fa-light fa-share-nodes` to the nav entry shipped in #1033. Every other page entry in `docs.yml` carries an icon — this brings it into line.

Self-merging per author authorization (cosmetic nav fix, no review needed).