### PR TITLE
Add changelog entry for week of April 27, 2026

### DIFF
--- a/fern/changelog/2026-04-27.mdx
+++ b/fern/changelog/2026-04-27.mdx
@@ -1,0 +1,3 @@
+# What's New: Week of April 27, 2026
+
+1. **Deepgram Flux — Multilingual Support**: Full support for Deepgram's multilingual Flux model. Multilingual agents can now leverage the same smart turn-taking that powers the English Flux transcriber, making cross-lingual conversations feel more fluid and natural.


### PR DESCRIPTION
## Description

Adds a new changelog entry under `fern/changelog/` for the week of April 27, 2026. Follows the merged April 13/20 entries from #1032 and renders at the top of `/whats-new` (above the existing Oct 2025 – March 2026 summary and the prior April weekly entries).

### Week of April 27, 2026 (`2026-04-27.mdx`)
- **Deepgram Flux — Multilingual Support** — full support for Deepgram's multilingual Flux model; multilingual agents can now leverage the same smart turn-taking that powers the English Flux transcriber, making cross-lingual conversations feel more fluid and natural

Complements the feature docs already shipped in #1034 (`feat: flux multilang`).

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Verify the new changelog entry renders correctly on `/whats-new` and appears above the previously merged April 13/20 entries

https://claude.ai/code/session_01LZKc1zrMXuAC3GXiGc4Gin

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZKc1zrMXuAC3GXiGc4Gin)_