### PR TITLE
fix: make subscribe email input text visible in light mode

### DIFF
--- a/fern/changelog/overview.mdx
+++ b/fern/changelog/overview.mdx
@@ -37,7 +37,7 @@ slug: whats-new
           fontSize: '0.875rem',
           outline: 'none',
           transition: 'border-color 0.2s ease-in-out',
-          color: '#fff',
+          color: '#1f2937',
           ':focus': {
             borderColor: '#4f46e5',
             boxShadow: '0 0 0 1px #4f46e5'


### PR DESCRIPTION
## Summary
- The email input in the "Subscribe to the latest product updates" card on `/whats-new` had its text color hard-coded to `#fff` (white), making the typed email invisible in light mode.
- Switched the default color to `#1f2937` (dark slate) so the text is readable in light mode; the existing `prefers-color-scheme: dark` override still applies `#f3f4f6` for users in dark mode.

## Test plan
- [ ] Visit https://docs.vapi.ai/whats-new in light mode and confirm typed email is visible.
- [ ] Visit https://docs.vapi.ai/whats-new in dark mode and confirm typed email remains visible (light text on dark background).
- [ ] Confirm placeholder text is still visible in both modes.

---
_Generated by [Claude Code](https://claude.ai/code/session_011J6f8ALXcXNk1qvvEEUQH9)_