### PR TITLE
Add changelog entry for Soniox GA release

### DIFF
--- a/fern/changelog/2026-05-04.mdx
+++ b/fern/changelog/2026-05-04.mdx
@@ -1,0 +1,3 @@
+# What's New: Week of May 4, 2026
+
+1. **Soniox — General Availability**: The Soniox transcriber is now available to all customers.

--- a/fern/changelog/2026-05-04.mdx
+++ b/fern/changelog/2026-05-04.mdx
@@ -1,3 +1,3 @@
 # What's New: Week of May 4, 2026
 
-1. **Soniox — General Availability**: The Soniox transcriber is now available to all customers.
+1. **Soniox — General Availability**: The Soniox transcriber is now rolled out to all customers — no waitlist or feature flag required. Configure it on any assistant via `assistant.transcriber` (provider: `soniox`) for low-latency, multilingual real-time speech-to-text.

--- a/fern/changelog/2026-05-04.mdx
+++ b/fern/changelog/2026-05-04.mdx
@@ -1,3 +1,3 @@
 # What's New: Week of May 4, 2026
 
-1. **Soniox — General Availability**: The Soniox transcriber is now rolled out to all customers — no waitlist or feature flag required. Configure it on any assistant via `assistant.transcriber` (provider: `soniox`) for low-latency, multilingual real-time speech-to-text.
+1. **Soniox — General Availability**: The Soniox transcriber is now rolled out to all customers. Configure it on any assistant via `assistant.transcriber` (provider: `soniox`) for low-latency, multilingual real-time speech-to-text.


### PR DESCRIPTION
## Description

- Added changelog entry documenting the general availability of Soniox transcriber for all customers
- Created new changelog file for the week of May 4, 2026

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Verify the changelog entry appears correctly on the documentation site

https://claude.ai/code/session_01LZKc1zrMXuAC3GXiGc4Gin