### PR TITLE
Add changelog entry for May 11, 2026 release

### DIFF
--- a/fern/changelog/2026-05-11.mdx
+++ b/fern/changelog/2026-05-11.mdx
@@ -1,5 +1,4 @@
 # What's New: Week of May 11, 2026
 
-1. **New Assistant Builder Experience**: A streamlined assistant configuration experience, now rolled out to 100% of users.
-
-2. **Phone Numbers UI Refresh**: UI style optimizations for the Phone Numbers page, aligning its look and interactions with the new Assistant Builder experience.
+1. **New Assistant Builder Experience**: An updated, streamlined assistant configuration experience, now available to all users.
+    - UI optimizations for the Phone Numbers page were also made to align its look and interactions with the new experience.

--- a/fern/changelog/2026-05-11.mdx
+++ b/fern/changelog/2026-05-11.mdx
@@ -1,0 +1,5 @@
+# What's New: Week of May 11, 2026
+
+1. **New Assistant Builder Experience**: A streamlined assistant configuration experience, now rolled out to 100% of users.
+
+2. **Phone Numbers UI Refresh**: UI style optimizations for the Phone Numbers page, aligning its look and interactions with the new Assistant Builder experience.


### PR DESCRIPTION
## Description

- Added changelog entry documenting the week of May 11, 2026
- Highlights new Assistant Builder Experience with streamlined configuration UI
- Documents UI optimizations made to the Phone Numbers page

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Verify the changelog entry renders correctly and is accessible from the documentation

https://claude.ai/code/session_01LZKc1zrMXuAC3GXiGc4Gin