### PR TITLE
Add changelog entry for week of May 18, 2026

### DIFF
--- a/fern/changelog/2026-05-18.mdx
+++ b/fern/changelog/2026-05-18.mdx
@@ -1,0 +1,5 @@
+# What's New: Week of May 18, 2026
+
+1. **Responsive UI Polish**: A round of UI adjustments to make the app work better across viewport sizes.
+
+2. **New Composer-Based Onboarding Flow**: A new onboarding experience built on top of the Assistant Builder and powered by Composer is rolling out to select users as part of a phased release.


### PR DESCRIPTION
## Description

- Added changelog entry documenting updates for the week of May 18, 2026
- Documented responsive UI polish improvements across viewport sizes
- Documented new Composer-based onboarding flow rolling out to select users

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Verify the changelog entry renders correctly and is accessible from the documentation

https://claude.ai/code/session_01LZKc1zrMXuAC3GXiGc4Gin