### PR TITLE
docs(whats-new): add Week of May 25, 2026 entry

### DIFF
--- a/fern/changelog/2026-05-25.mdx
+++ b/fern/changelog/2026-05-25.mdx
@@ -1,0 +1,3 @@
+# What's New: Week of May 25, 2026
+
+1. **Dashboard Performance**: Front-end infrastructure improvements for faster page loads and a snappier feel across the dashboard.


### PR DESCRIPTION
## Summary
- Adds `fern/changelog/2026-05-25.mdx` with a single Dashboard Performance entry summarizing this week's front-end infrastructure work.

## Test plan
- [x] Preview renders the entry at the top of `/whats-new`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)