### PR TITLE
docs: add EU SIP region endpoints

### DIFF
--- a/fern/advanced/sip/sip-networking.mdx
+++ b/fern/advanced/sip/sip-networking.mdx
@@ -20,24 +20,28 @@ When you integrate a SIP trunk with Vapi, your firewall and network infrastructu
 
 ## Quick reference
 
-The table below summarizes every IP address, port, and protocol you need to allowlist.
+The table below summarizes every IP address, port, and protocol you need to allowlist. Use the row that matches the Vapi region where your organization is hosted.
 
-| Traffic type | IP addresses | Ports | Protocol | Direction |
-| --- | --- | --- | --- | --- |
-| SIP signalling | `44.229.228.186`, `44.238.177.138` | `5060` | UDP | Bidirectional |
-| SIP signalling (TLS) | `44.229.228.186`, `44.238.177.138` | `5061` | TLS | Bidirectional |
-| RTP media | No static IPs (dynamic) | `40000`-`60000` | UDP | Bidirectional |
+| Traffic type | Region | Hostname | IP addresses | Ports | Protocol | Direction |
+| --- | --- | --- | --- | --- | --- | --- |
+| SIP signalling | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5060` | UDP | Bidirectional |
+| SIP signalling | EU | `sip.eu.vapi.ai` | `44.233.34.47`, `44.233.34.48` | `5060` | UDP | Bidirectional |
+| SIP signalling (TLS) | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5061` | TLS | Bidirectional |
+| SIP signalling (TLS) | EU | `sip.eu.vapi.ai` | `44.233.34.47`, `44.233.34.48` | `5061` | TLS | Bidirectional |
+| RTP media | All regions | N/A | No static IPs (dynamic) | `40000`-`60000` | UDP | Bidirectional |
 
-You can also use the DNS hostname `sip.vapi.ai`, which resolves to the SIP signalling IP addresses listed above.
+Use your region's SIP hostname when configuring SIP URIs or SIP peers. If your firewall or SIP provider requires IP-based allowlisting, add the signalling IP addresses for your region explicitly.
 
 ## SIP signalling
 
-Vapi's SIP infrastructure uses two static IP addresses for all signalling traffic:
+Vapi's SIP infrastructure uses two static IP addresses for signalling traffic in each region:
 
-- `44.229.228.186/32`
-- `44.238.177.138/32`
+| Region | Hostname | IP addresses |
+| --- | --- | --- |
+| US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32` |
+| EU | `sip.eu.vapi.ai` | `44.233.34.47/32`, `44.233.34.48/32` |
 
-These are the public IPs of Vapi's SBC (Session Border Controller) nodes. All SIP `INVITE`, `REGISTER`, `BYE`, and other signalling messages originate from and are received at these addresses.
+These are the public IPs of Vapi's SBC (Session Border Controller) nodes. All SIP `INVITE`, `REGISTER`, `BYE`, and other signalling messages originate from and are received at the addresses for your region.
 
 ### Ports
 
@@ -48,12 +52,12 @@ These are the public IPs of Vapi's SBC (Session Border Controller) nodes. All SI
 
 Use port **5060** unless your provider or security requirements mandate encrypted signalling, in which case use port **5061** with TLS.
 
-### DNS resolution
+### Hostnames and allowlisting
 
-The hostname `sip.vapi.ai` resolves to both signalling IP addresses. You can configure your SIP client or PBX to point to `sip.vapi.ai` instead of using the IP addresses directly.
+Configure your SIP client or PBX to point to the hostname for your region. For firewall rules and carrier allowlists, use the static signalling IP addresses listed for your region.
 
 <Tip>
-  If your firewall rules are IP-based, allowlist both IP addresses explicitly rather than relying on DNS resolution. DNS-based rules may not update immediately if the resolution changes.
+  Allowlist both IP addresses for your region explicitly. DNS A records may not match every static signalling IP that Vapi can use for carrier or firewall allowlisting.
 </Tip>
 
 ## SIP media (RTP)
@@ -82,43 +86,47 @@ Vapi uses **UDP ports 40000 through 60000** for RTP media traffic.
 
 ## Firewall rules
 
-Configure your firewall to allow the following traffic. Both SIP signalling IP addresses must be allowlisted, as Vapi may use either one for any given call. For RTP media, allow traffic on the full port range without IP restrictions since Vapi uses dynamic IPs for media.
+Configure your firewall to allow the following traffic. Both SIP signalling IP addresses for your region must be allowlisted, as Vapi may use either one for any given call. For RTP media, allow traffic on the full port range without IP restrictions since Vapi uses dynamic IPs for media.
 
 ### Inbound rules (traffic from Vapi to your network)
 
 Allow these if your SIP provider or PBX needs to receive traffic from Vapi:
 
-| Rule | Source IP | Destination | Port(s) | Protocol |
-| --- | --- | --- | --- | --- |
-| SIP signalling | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5060` | UDP |
-| SIP signalling (TLS) | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5061` | TLS |
-| RTP media | Any (dynamic) | Your media server | `40000`-`60000` | UDP |
+| Rule | Region | Source IP | Destination | Port(s) | Protocol |
+| --- | --- | --- | --- | --- | --- |
+| SIP signalling | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5060` | UDP |
+| SIP signalling | EU | `44.233.34.47`, `44.233.34.48` | Your SIP server | `5060` | UDP |
+| SIP signalling (TLS) | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5061` | TLS |
+| SIP signalling (TLS) | EU | `44.233.34.47`, `44.233.34.48` | Your SIP server | `5061` | TLS |
+| RTP media | All regions | Any (dynamic) | Your media server | `40000`-`60000` | UDP |
 
 ### Outbound rules (traffic from your network to Vapi)
 
 Allow these if your firewall restricts outbound connections:
 
-| Rule | Source | Destination IP | Port(s) | Protocol |
-| --- | --- | --- | --- | --- |
-| SIP signalling | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5060` | UDP |
-| SIP signalling (TLS) | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5061` | TLS |
-| RTP media | Your media server | Any (dynamic) | `40000`-`60000` | UDP |
+| Rule | Region | Source | Destination IP | Port(s) | Protocol |
+| --- | --- | --- | --- | --- | --- |
+| SIP signalling | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5060` | UDP |
+| SIP signalling | EU | Your SIP server | `44.233.34.47`, `44.233.34.48` | `5060` | UDP |
+| SIP signalling (TLS) | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5061` | TLS |
+| SIP signalling (TLS) | EU | Your SIP server | `44.233.34.47`, `44.233.34.48` | `5061` | TLS |
+| RTP media | All regions | Your media server | Any (dynamic) | `40000`-`60000` | UDP |
 
 <Warning>
-  Both SIP signalling IP addresses must be allowed in your firewall rules. Vapi may use either address for signalling on any given call. Missing one address can cause intermittent call failures. For RTP media, since Vapi uses dynamic IPs, configure your firewall to allow the full port range (`40000`-`60000` UDP) without restricting by source or destination IP.
+  Both SIP signalling IP addresses for your region must be allowed in your firewall rules. Vapi may use either address for signalling on any given call. Missing one address can cause intermittent call failures. For RTP media, since Vapi uses dynamic IPs, configure your firewall to allow the full port range (`40000`-`60000` UDP) without restricting by source or destination IP.
 </Warning>
 
 ## FAQ
 
 <AccordionGroup>
   <Accordion title="Can I use DNS instead of IP addresses in my firewall rules?">
-    The hostname `sip.vapi.ai` resolves to both Vapi SIP signalling IP addresses. However, if your firewall supports only IP-based rules, add both `44.229.228.186` and `44.238.177.138` explicitly for signalling. DNS-based firewall rules depend on TTL and caching behavior, which can lead to gaps during DNS updates. Note that this DNS hostname applies to SIP signalling only; RTP media uses dynamic IPs that cannot be resolved via DNS.
+    Use your region's hostname for SIP URI and peer configuration. For IP-based firewall rules, add both static signalling IP addresses for your region explicitly. DNS-based firewall rules depend on TTL and caching behavior, and DNS A records may not match every static signalling IP that Vapi can use for allowlisting. RTP media uses dynamic IPs that cannot be resolved via DNS.
   </Accordion>
   <Accordion title="Do I need to open the full 40000-60000 port range?">
     Yes. Vapi's RTP stack dynamically allocates ports within this range for each call. You cannot predict which specific port a given call will use, so the entire range must be open for reliable media flow.
   </Accordion>
   <Accordion title="Are the signalling and media IPs the same?">
-    No. Vapi's SIP signalling uses the static IP addresses `44.229.228.186` and `44.238.177.138`, but RTP media does not use static IP addresses. Media source IPs are dynamically assigned and may vary between calls.
+    No. Vapi's SIP signalling uses static IP addresses for each region, but RTP media does not use static IP addresses. Media source IPs are dynamically assigned and may vary between calls.
   </Accordion>
   <Accordion title="Does Vapi support SRTP (encrypted media)?">
     Vapi supports TLS for SIP signalling on port 5061. For encrypted media (SRTP), configure your SIP trunk gateway with the `tls/srtp` outbound protocol option. See the [gateway configuration reference](/advanced/sip/troubleshoot-sip-trunk-credential-errors#gateway-configuration-reference) for details.

--- a/fern/advanced/sip/sip.mdx
+++ b/fern/advanced/sip/sip.mdx
@@ -8,6 +8,31 @@ slug: advanced/sip
 
 This guide shows you how to set up and test SIP calls to your Vapi assistant using any SIP client or softphone. You'll create an assistant, assign it a SIP phone number, and make a call using a SIP URI. You can also pass template variables via SIP headers.
 
+## Choose your Vapi region
+
+Use the API base URL, private key, and SIP host from the same Vapi region. Do not create a SIP phone number in one region with a SIP URI from another region.
+
+| Region | Dashboard | API base URL | SIP host |
+| --- | --- | --- | --- |
+| United States | `dashboard.vapi.ai` | `https://api.vapi.ai` | `sip.vapi.ai` |
+| European Union | `dashboard.eu.vapi.ai` | `https://api.eu.vapi.ai` | `sip.eu.vapi.ai` |
+
+For EU organizations, create the SIP phone number against the EU API with an EU dashboard private key:
+
+```bash
+curl -X POST https://api.eu.vapi.ai/phone-number \
+  -H "Authorization: Bearer $VAPI_EU_PRIVATE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "vapi",
+    "name": "EU SIP Assistant",
+    "sipUri": "sip:your_unique_user_name@sip.eu.vapi.ai",
+    "assistantId": "your_eu_assistant_id"
+  }'
+```
+
+If your SIP provider or firewall requires IP allowlisting, use the signalling IPs for your region from the [SIP networking and firewall configuration](/advanced/sip/sip-networking) reference.
+
 <Steps>
   <Step title="Create an assistant">
     Create an assistant with the `POST /assistant` endpoint. This is the same as creating an assistant for any other transport.
@@ -20,7 +45,7 @@ This guide shows you how to set up and test SIP calls to your Vapi assistant usi
   </Step>
 
   <Step title="Create a SIP phone number">
-    Create a SIP phone number with the `POST /phone-number` endpoint.
+    Create a SIP phone number with the `POST /phone-number` endpoint for your region.
     ```json
     {
       "provider": "vapi",
@@ -29,7 +54,7 @@ This guide shows you how to set up and test SIP calls to your Vapi assistant usi
     }
     ```
     <Info>
-      `sipUri` must be in the format `sip:username@sip.vapi.ai`. You can choose any username you like.
+      `sipUri` must be in the format `sip:username@<sip-host>`, where `<sip-host>` matches your Vapi region. You can choose any username you like.
     </Info>
   </Step>
 


### PR DESCRIPTION
## Description

- Update `fern/advanced/sip/sip.mdx` with US/EU region selection guidance for dashboard, API base URL, and SIP host.
- Add an EU `POST /phone-number` cURL example using `https://api.eu.vapi.ai`, `sip.eu.vapi.ai`, and an EU dashboard private key.
- Update `fern/advanced/sip/sip-networking.mdx` with EU SIP signalling host and allowlist IPs alongside the existing US values.
- Source: Linear PRISM-760.

Resolves PRISM-760

## Testing Steps

- [x] Run `fern check` -- passes with no errors
- [x] Verify JSON examples are valid (no syntax errors in code blocks)
- [x] Verify internal links resolve to existing pages
- [ ] Confirm updated pages render at expected URLs in the preview deployment
- [x] Review page content for style guide compliance (active voice, present tense, no marketing language)
- [x] Verify code examples include all imports and use env vars for secrets
- [x] Cross-check region/SIP endpoint documentation against Linear source and current Vapi SIP realm config

![image.png](https://app.graphite.com/user-attachments/assets/048cd10d-0c6d-4e0d-bf88-98630051156a.png)

