### PR TITLE
docs(api-reference): add hidden Simulations API reference

### DIFF
--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -233,8 +233,1660 @@ paths:
       x-fern-sdk-group-name:
         - logs
       x-fern-sdk-method-name: get
+  # --- Simulations (alpha) endpoints: documented in the API reference but hidden from
+  # nav/search via docs.yml. Sourced from api.vapi.ai/api-alpha-json (not in the public
+  # api-json this spec syncs from). Reuses the Assistant/etc schemas already in the spec.
+  /eval/simulation/personality:
+    post:
+      operationId: PersonalityController_create
+      summary: Create Personality
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePersonalityDTO'
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Personality'
+      tags:
+      - Simulation Personalities
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationPersonalities
+      x-fern-sdk-method-name: create
+    get:
+      operationId: PersonalityController_findAll
+      summary: List Personalities
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: This is the page number to return. Defaults to 1.
+        schema:
+          minimum: 1
+          type: number
+      - name: sortOrder
+        required: false
+        in: query
+        description: This is the sort order for pagination. Defaults to 'DESC'.
+        schema:
+          enum:
+          - ASC
+          - DESC
+          type: string
+      - name: sortBy
+        required: false
+        in: query
+        description: This is the column to sort by. Defaults to 'createdAt'.
+        schema:
+          enum:
+          - createdAt
+          - duration
+          - cost
+          type: string
+      - name: limit
+        required: false
+        in: query
+        description: This is the maximum number of items to return. Defaults to 100.
+        schema:
+          minimum: 0
+          maximum: 1000
+          type: number
+      - name: createdAtGt
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLt
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtGe
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLe
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Personality'
+      tags:
+      - Simulation Personalities
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationPersonalities
+      x-fern-sdk-method-name: list
+  /eval/simulation/personality/{id}:
+    get:
+      operationId: PersonalityController_findOne
+      summary: Get Personality
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Personality'
+      tags:
+      - Simulation Personalities
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationPersonalities
+      x-fern-sdk-method-name: get
+    patch:
+      operationId: PersonalityController_update
+      summary: Update Personality
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePersonalityDTO'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Personality'
+      tags:
+      - Simulation Personalities
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationPersonalities
+      x-fern-sdk-method-name: update
+    delete:
+      operationId: PersonalityController_remove
+      summary: Delete Personality
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Personality'
+      tags:
+      - Simulation Personalities
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationPersonalities
+      x-fern-sdk-method-name: delete
+  /eval/simulation/scenario:
+    post:
+      operationId: ScenarioController_create
+      summary: Create Scenario
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateScenarioDTO'
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Scenario'
+      tags:
+      - Simulation Scenarios
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationScenarios
+      x-fern-sdk-method-name: create
+    get:
+      operationId: ScenarioController_findAll
+      summary: List Scenarios
+      parameters:
+      - name: idAny
+        required: false
+        in: query
+        description: Return only scenarios matching the provided ids
+        schema:
+          format: uuid
+          type: array
+          items:
+            type: string
+      - name: name
+        required: false
+        in: query
+        description: Search by scenario name
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: This is the page number to return. Defaults to 1.
+        schema:
+          minimum: 1
+          type: number
+      - name: sortOrder
+        required: false
+        in: query
+        description: This is the sort order for pagination. Defaults to 'DESC'.
+        schema:
+          enum:
+          - ASC
+          - DESC
+          type: string
+      - name: sortBy
+        required: false
+        in: query
+        description: This is the column to sort by. Defaults to 'createdAt'.
+        schema:
+          enum:
+          - createdAt
+          - duration
+          - cost
+          type: string
+      - name: limit
+        required: false
+        in: query
+        description: This is the maximum number of items to return. Defaults to 100.
+        schema:
+          minimum: 0
+          maximum: 1000
+          type: number
+      - name: createdAtGt
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLt
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtGe
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLe
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Scenario'
+      tags:
+      - Simulation Scenarios
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationScenarios
+      x-fern-sdk-method-name: list
+  /eval/simulation/scenario/{id}:
+    get:
+      operationId: ScenarioController_findOne
+      summary: Get Scenario
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Scenario'
+      tags:
+      - Simulation Scenarios
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationScenarios
+      x-fern-sdk-method-name: get
+    patch:
+      operationId: ScenarioController_update
+      summary: Update Scenario
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateScenarioDTO'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Scenario'
+      tags:
+      - Simulation Scenarios
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationScenarios
+      x-fern-sdk-method-name: update
+    delete:
+      operationId: ScenarioController_remove
+      summary: Delete Scenario
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Scenario'
+      tags:
+      - Simulation Scenarios
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationScenarios
+      x-fern-sdk-method-name: delete
+  /eval/simulation/run:
+    post:
+      operationId: SimulationRunController_create
+      summary: Create Simulation Run
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSimulationRunDTO'
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationRun'
+      tags:
+      - Simulation Runs
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationRuns
+      x-fern-sdk-method-name: create
+    get:
+      operationId: SimulationRunController_findAll
+      summary: List Simulation Runs
+      parameters:
+      - name: status
+        required: false
+        in: query
+        description: Filter by status
+        schema:
+          enum:
+          - queued
+          - running
+          - ended
+          type: string
+      - name: filterStatus
+        required: false
+        in: query
+        description: Filter by aggregate run result status
+        schema:
+          enum:
+          - passed
+          - failed
+          - running
+          type: string
+      - name: targetType
+        required: false
+        in: query
+        description: Filter by target type
+        schema:
+          enum:
+          - assistant
+          - squad
+          type: string
+      - name: targetId
+        required: false
+        in: query
+        description: Filter by target id
+        schema:
+          format: uuid
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: This is the page number to return. Defaults to 1.
+        schema:
+          minimum: 1
+          type: number
+      - name: sortOrder
+        required: false
+        in: query
+        description: This is the sort order for pagination. Defaults to 'DESC'.
+        schema:
+          enum:
+          - ASC
+          - DESC
+          type: string
+      - name: sortBy
+        required: false
+        in: query
+        description: This is the column to sort by. Defaults to 'createdAt'.
+        schema:
+          enum:
+          - createdAt
+          - duration
+          - cost
+          type: string
+      - name: limit
+        required: false
+        in: query
+        description: This is the maximum number of items to return. Defaults to 100.
+        schema:
+          minimum: 0
+          maximum: 1000
+          type: number
+      - name: createdAtGt
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLt
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtGe
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLe
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SimulationRun'
+      tags:
+      - Simulation Runs
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationRuns
+      x-fern-sdk-method-name: list
+  /eval/simulation/run/{id}:
+    get:
+      operationId: SimulationRunController_findOne
+      summary: Get Simulation Run
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationRun'
+      tags:
+      - Simulation Runs
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationRuns
+      x-fern-sdk-method-name: get
+    patch:
+      operationId: SimulationRunController_cancelGroup
+      summary: Cancel Simulation Run
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationRun'
+      tags:
+      - Simulation Runs
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationRuns
+      x-fern-sdk-method-name: cancel
+  /eval/simulation/run/{id}/item:
+    get:
+      operationId: SimulationRunController_findItems
+      summary: List Simulation Run Items
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      - name: simulationId
+        required: false
+        in: query
+        description: This is the simulation ID to filter by.
+        schema:
+          format: uuid
+          type: string
+      - name: runId
+        required: false
+        in: query
+        description: This is the run ID (batch/group) to filter by.
+        schema:
+          format: uuid
+          type: string
+      - name: status
+        required: false
+        in: query
+        description: This is the status to filter by.
+        schema:
+          enum:
+          - queued
+          - running
+          - evaluating
+          - passed
+          - failed
+          - canceled
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: This is the page number to return. Defaults to 1.
+        schema:
+          minimum: 1
+          type: number
+      - name: sortOrder
+        required: false
+        in: query
+        description: This is the sort order for pagination. Defaults to 'DESC'.
+        schema:
+          enum:
+          - ASC
+          - DESC
+          type: string
+      - name: sortBy
+        required: false
+        in: query
+        description: This is the column to sort by. Defaults to 'createdAt'.
+        schema:
+          enum:
+          - createdAt
+          - duration
+          - cost
+          type: string
+      - name: limit
+        required: false
+        in: query
+        description: This is the maximum number of items to return. Defaults to 100.
+        schema:
+          minimum: 0
+          maximum: 1000
+          type: number
+      - name: createdAtGt
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLt
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtGe
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLe
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SimulationRunItem'
+      tags:
+      - Simulation Run Items
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationRunItems
+      x-fern-sdk-method-name: list
+  /eval/simulation/run/{id}/item/{itemId}:
+    get:
+      operationId: SimulationRunController_findItem
+      summary: Get Simulation Run Item
+      parameters:
+      - name: id
+        required: true
+        in: path
+        schema:
+          type: string
+      - name: itemId
+        required: true
+        in: path
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationRunItem'
+      tags:
+      - Simulation Run Items
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationRunItems
+      x-fern-sdk-method-name: get
+    patch:
+      operationId: SimulationRunController_cancelItem
+      summary: Cancel Simulation Run Item
+      parameters:
+      - name: id
+        required: true
+        in: path
+        schema:
+          type: string
+      - name: itemId
+        required: true
+        in: path
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationRunItem'
+      tags:
+      - Simulation Run Items
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationRunItems
+      x-fern-sdk-method-name: cancel
+  /eval/simulation/run/{id}/item/{itemId}/generate:
+    post:
+      operationId: SimulationRunController_generateSuggestions
+      summary: Generate Improvement Suggestions
+      parameters:
+      - name: id
+        required: true
+        in: path
+        schema:
+          type: string
+      - name: itemId
+        required: true
+        in: path
+        schema:
+          type: string
+      - name: force
+        required: true
+        in: query
+        schema:
+          type: string
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+      tags:
+      - Simulation Run Items
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationRunItems
+      x-fern-sdk-method-name: generateSuggestions
+  /eval/simulation/suite:
+    post:
+      operationId: SimulationSuiteController_create
+      summary: Create Simulation Suite
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSimulationSuiteDTO'
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationSuite'
+      tags:
+      - Simulation Suites
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationSuites
+      x-fern-sdk-method-name: create
+    get:
+      operationId: SimulationSuiteController_findAll
+      summary: List Simulation Suites
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: This is the page number to return. Defaults to 1.
+        schema:
+          minimum: 1
+          type: number
+      - name: sortOrder
+        required: false
+        in: query
+        description: This is the sort order for pagination. Defaults to 'DESC'.
+        schema:
+          enum:
+          - ASC
+          - DESC
+          type: string
+      - name: sortBy
+        required: false
+        in: query
+        description: This is the column to sort by. Defaults to 'createdAt'.
+        schema:
+          enum:
+          - createdAt
+          - duration
+          - cost
+          type: string
+      - name: limit
+        required: false
+        in: query
+        description: This is the maximum number of items to return. Defaults to 100.
+        schema:
+          minimum: 0
+          maximum: 1000
+          type: number
+      - name: createdAtGt
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLt
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtGe
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLe
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SimulationSuite'
+      tags:
+      - Simulation Suites
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationSuites
+      x-fern-sdk-method-name: list
+  /eval/simulation/suite/{id}:
+    get:
+      operationId: SimulationSuiteController_findOne
+      summary: Get Simulation Suite
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationSuite'
+      tags:
+      - Simulation Suites
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationSuites
+      x-fern-sdk-method-name: get
+    patch:
+      operationId: SimulationSuiteController_update
+      summary: Update Simulation Suite
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSimulationSuiteDTO'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationSuite'
+      tags:
+      - Simulation Suites
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationSuites
+      x-fern-sdk-method-name: update
+    delete:
+      operationId: SimulationSuiteController_remove
+      summary: Delete Simulation Suite
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationSuite'
+      tags:
+      - Simulation Suites
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulationSuites
+      x-fern-sdk-method-name: delete
+  /eval/simulation/scenario/generate:
+    post:
+      operationId: SimulationGenerateController_generate
+      summary: Generate Scenarios with AI
+      description: Uses AI to analyze an assistant or squad configuration and generate test scenarios
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateScenariosDTO'
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateScenariosResponse'
+      tags:
+      - Simulations
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulations
+      x-fern-sdk-method-name: generateScenarios
+  /eval/simulation:
+    post:
+      operationId: SimulationController_create
+      summary: Create Simulation
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSimulationDTO'
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Simulation'
+      tags:
+      - Simulations
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulations
+      x-fern-sdk-method-name: create
+    get:
+      operationId: SimulationController_findAll
+      summary: List Simulations
+      parameters:
+      - name: idAny
+        required: false
+        in: query
+        description: Return only simulations matching the provided ids
+        schema:
+          format: uuid
+          type: array
+          items:
+            type: string
+      - name: standaloneOnly
+        required: false
+        in: query
+        description: Only include simulations that are not part of a suite
+        schema:
+          type: boolean
+      - name: page
+        required: false
+        in: query
+        description: This is the page number to return. Defaults to 1.
+        schema:
+          minimum: 1
+          type: number
+      - name: sortOrder
+        required: false
+        in: query
+        description: This is the sort order for pagination. Defaults to 'DESC'.
+        schema:
+          enum:
+          - ASC
+          - DESC
+          type: string
+      - name: sortBy
+        required: false
+        in: query
+        description: This is the column to sort by. Defaults to 'createdAt'.
+        schema:
+          enum:
+          - createdAt
+          - duration
+          - cost
+          type: string
+      - name: limit
+        required: false
+        in: query
+        description: This is the maximum number of items to return. Defaults to 100.
+        schema:
+          minimum: 0
+          maximum: 1000
+          type: number
+      - name: createdAtGt
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLt
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtGe
+        required: false
+        in: query
+        description: This will return items where the createdAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: createdAtLe
+        required: false
+        in: query
+        description: This will return items where the createdAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLt
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtGe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is greater than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      - name: updatedAtLe
+        required: false
+        in: query
+        description: This will return items where the updatedAt is less than or equal to the specified value.
+        schema:
+          format: date-time
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Simulation'
+      tags:
+      - Simulations
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulations
+      x-fern-sdk-method-name: list
+  /eval/simulation/{id}:
+    get:
+      operationId: SimulationController_findOne
+      summary: Get Simulation
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Simulation'
+      tags:
+      - Simulations
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulations
+      x-fern-sdk-method-name: get
+    patch:
+      operationId: SimulationController_update
+      summary: Update Simulation
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSimulationDTO'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Simulation'
+      tags:
+      - Simulations
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulations
+      x-fern-sdk-method-name: update
+    delete:
+      operationId: SimulationController_remove
+      summary: Delete Simulation
+      parameters:
+      - name: id
+        required: true
+        in: path
+        description: The unique identifier for the resource.
+        schema:
+          format: uuid
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Simulation'
+      tags:
+      - Simulations
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulations
+      x-fern-sdk-method-name: delete
+  /eval/simulation/concurrency:
+    get:
+      operationId: SimulationController_getConcurrency
+      summary: Get Simulation Concurrency
+      parameters: []
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationConcurrencyResponse'
+      tags:
+      - Simulations
+      security:
+      - bearer: []
+      x-fern-sdk-group-name:
+      - simulations
+      x-fern-sdk-method-name: getConcurrency
 components:
   schemas:
+    # Newer provider schemas referenced by Simulation run targets, not yet in the synced base.
+    ContextEngineeringPlanPreviousAssistantMessages:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - previousAssistantMessages
+      required:
+      - type
+    FallbackXaiTranscriber:
+      type: object
+      properties:
+        provider:
+          type: string
+          enum:
+          - xai
+        model:
+          type: string
+          description: The xAI speech-to-text model to use. xAI currently exposes a single STT model — placeholder for future model selection.
+          enum:
+          - default
+        language:
+          type: string
+          description: Single language for transcription as an ISO 639-1 code (e.g., `en`, `es`). Defaults to `en` if not set. xAI auto-detects when omitted via the API but Vapi defaults to English for deterministic behavior.
+          enum:
+          - ar
+          - cs
+          - da
+          - nl
+          - en
+          - fil
+          - fr
+          - de
+          - hi
+          - id
+          - it
+          - ja
+          - ko
+          - mk
+          - ms
+          - fa
+          - pl
+          - pt
+          - ro
+          - ru
+          - es
+          - sv
+          - th
+          - tr
+          - vi
+      required:
+      - provider
+    FallbackXaiVoice:
+      type: object
+      properties:
+        cachingEnabled:
+          type: boolean
+          description: This is the flag to toggle voice caching for the assistant.
+          example: true
+          default: true
+        provider:
+          type: string
+          description: This is the voice provider that will be used.
+          enum:
+          - xai
+        voiceId:
+          type: string
+          description: 'Built-in voices: eve, ara, rex, sal, leo. Cloned voice IDs are also accepted.'
+          maxLength: 120
+          title: xAI Voice ID
+          enum:
+          - eve
+          - ara
+          - rex
+          - sal
+          - leo
+          example: eve
+        language:
+          type: string
+          description: BCP-47 language code for xAI TTS synthesis.
+          enum:
+          - auto
+          - en
+          - ar-EG
+          - ar-SA
+          - ar-AE
+          - bn
+          - zh
+          - fr
+          - de
+          - hi
+          - id
+          - it
+          - ja
+          - ko
+          - pt-BR
+          - pt-PT
+          - ru
+          - es-MX
+          - es-ES
+          - tr
+          - vi
+          default: en
+        speed:
+          type: number
+          description: Speed multiplier for xAI TTS synthesis.
+          minimum: 0.7
+          maximum: 1.5
+          default: 1.1
+        chunkPlan:
+          description: This is the plan for chunking the model output before it is sent to the voice provider.
+          allOf:
+          - $ref: '#/components/schemas/ChunkPlan'
+      required:
+      - provider
+      - voiceId
+    SonioxContextGeneralItem:
+      type: object
+      properties:
+        key:
+          type: string
+          description: The key describing the type of context (e.g., "domain", "topic", "doctor", "organization").
+          minLength: 1
+          example: domain
+        value:
+          type: string
+          description: The value for the context key (e.g., "Healthcare", "Diabetes management consultation").
+          minLength: 1
+          example: Healthcare
+      required:
+      - key
+      - value
+    XaiTranscriber:
+      type: object
+      properties:
+        provider:
+          type: string
+          enum:
+          - xai
+        model:
+          type: string
+          description: The xAI speech-to-text model to use. xAI currently exposes a single STT model — placeholder for future model selection.
+          enum:
+          - default
+        language:
+          type: string
+          description: Single language for transcription as an ISO 639-1 code (e.g., `en`, `es`). Defaults to `en` if not set. xAI auto-detects when omitted via the API but Vapi defaults to English for deterministic behavior.
+          enum:
+          - ar
+          - cs
+          - da
+          - nl
+          - en
+          - fil
+          - fr
+          - de
+          - hi
+          - id
+          - it
+          - ja
+          - ko
+          - mk
+          - ms
+          - fa
+          - pl
+          - pt
+          - ro
+          - ru
+          - es
+          - sv
+          - th
+          - tr
+          - vi
+        fallbackPlan:
+          description: This is the plan for transcriber provider fallbacks in the event that the primary transcriber provider fails.
+          allOf:
+          - $ref: '#/components/schemas/FallbackTranscriberPlan'
+      required:
+      - provider
+    XaiVoice:
+      type: object
+      properties:
+        cachingEnabled:
+          type: boolean
+          description: This is the flag to toggle voice caching for the assistant.
+          example: true
+          default: true
+        provider:
+          type: string
+          description: This is the voice provider that will be used.
+          enum:
+          - xai
+        voiceId:
+          type: string
+          description: 'Built-in voices: eve, ara, rex, sal, leo. Cloned voice IDs are also accepted.'
+          maxLength: 120
+          title: xAI Voice ID
+          enum:
+          - eve
+          - ara
+          - rex
+          - sal
+          - leo
+          example: eve
+        language:
+          type: string
+          description: BCP-47 language code for xAI TTS synthesis.
+          enum:
+          - auto
+          - en
+          - ar-EG
+          - ar-SA
+          - ar-AE
+          - bn
+          - zh
+          - fr
+          - de
+          - hi
+          - id
+          - it
+          - ja
+          - ko
+          - pt-BR
+          - pt-PT
+          - ru
+          - es-MX
+          - es-ES
+          - tr
+          - vi
+          default: en
+        speed:
+          type: number
+          description: Speed multiplier for xAI TTS synthesis.
+          minimum: 0.7
+          maximum: 1.5
+          default: 1.1
+        chunkPlan:
+          description: This is the plan for chunking the model output before it is sent to the voice provider.
+          allOf:
+          - $ref: '#/components/schemas/ChunkPlan'
+        fallbackPlan:
+          description: This is the plan for voice provider fallbacks in the event that the primary voice provider fails.
+          allOf:
+          - $ref: '#/components/schemas/FallbackPlan'
+      required:
+      - provider
+      - voiceId
     CreateAssistantDTO:
       properties:
         serverMessages:


### PR DESCRIPTION
Adds the alpha simulation endpoints (Simulations, Runs, Run Items, Suites, Scenarios, Personalities — 15 paths) to the API reference as a hidden page: not shown in the sidebar or search (noindex), but reachable by direct URL.

These endpoints are tagged 'alpha' in the backend and are stripped from the public api-json that the docs sync pulls from, so they are documented here via a self-contained, docs-only API definition (apis/simulations/, no SDK generators) snapshotted from the alpha OpenAPI. No vapi backend changes.

## Description

<!-- describe the changes as bullet points -->
- 
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
