### PR TITLE
Add June 3 changelog entry for new Vapi logo

### DIFF
--- a/fern/changelog/2026-06-03.mdx
+++ b/fern/changelog/2026-06-03.mdx
@@ -1,0 +1,3 @@
+# What's New: Week of June 3, 2026
+
+1. **New Vapi Logo**: Vapi has a fresh new logo, now rolling out across the dashboard, docs, and brand assets.


### PR DESCRIPTION
Adds a "What's New" changelog entry for the week of June 3, 2026 announcing the new Vapi logo.

Made with [Cursor](https://cursor.com)