### PR TITLE
docs(whats-new): add Week of June 1, 2026 entry

### DIFF
--- a/fern/changelog/2026-06-01.mdx
+++ b/fern/changelog/2026-06-01.mdx
@@ -2,7 +2,9 @@
 
 1. **xAI Speech-to-Text and Text-to-Speech**: xAI is now available as a transcriber (STT) and voice (TTS) provider for assistants.
 
-2. **New Vapi Voices**: Three new voices — Emma, Clara, and Nico — join the [Vapi Voices](https://docs.vapi.ai/providers/voice/vapi-voices) collection.
+2. **Upgraded Vapi Voices**: A new text-to-speech model powering [Vapi Voices](https://docs.vapi.ai/providers/voice/vapi-voices) makes them sound more authentic, human, and consistent — at ~50% lower cost.
+    - Available for Clara, Godfrey, Layla, Sid, Elliot, Savannah, Nico, Kai, Emma, Sagar, Neil, and Naina.
+    - Existing deployments don't change automatically — opt in by setting `version: 2` on the voice configuration via the API or Dashboard.
 
 3. **Pronunciation Dictionaries in the Dashboard**: The Assistants view now supports creating new [pronunciation dictionaries](https://docs.vapi.ai/assistants/pronunciation-dictionaries) directly from the dashboard.
 

--- a/fern/changelog/2026-06-01.mdx
+++ b/fern/changelog/2026-06-01.mdx
@@ -3,8 +3,7 @@
 1. **xAI Speech-to-Text and Text-to-Speech**: xAI is now available as a transcriber (STT) and voice (TTS) provider for assistants.
 
 2. **Upgraded Vapi Voices**: A new text-to-speech model powering [Vapi Voices](https://docs.vapi.ai/providers/voice/vapi-voices) makes them sound more authentic, human, and consistent — at ~50% lower cost.
-    - Available for Clara, Godfrey, Layla, Sid, Elliot, Savannah, Nico, Kai, Emma, Sagar, Neil, and Naina.
-    - Existing deployments don't change automatically — opt in by setting `version: 2` on the voice configuration via the API or Dashboard.
+    - Existing deployments don't change automatically — opt in by setting `version: 2` on the voice configuration via the API or Dashboard. See [Vapi Voices](https://docs.vapi.ai/providers/voice/vapi-voices) for supported voices and audio samples.
 
 3. **Pronunciation Dictionaries in the Dashboard**: The Assistants view now supports creating new [pronunciation dictionaries](https://docs.vapi.ai/assistants/pronunciation-dictionaries) directly from the dashboard.
 

--- a/fern/changelog/2026-06-01.mdx
+++ b/fern/changelog/2026-06-01.mdx
@@ -1,0 +1,11 @@
+# What's New: Week of June 1, 2026
+
+1. **xAI Speech-to-Text and Text-to-Speech**: xAI is now available as a transcriber (STT) and voice (TTS) provider for assistants.
+
+2. **New Vapi Voices**: Three new voices — Emma, Clara, and Nico — join the [Vapi Voices](https://docs.vapi.ai/providers/voice/vapi-voices) collection.
+
+3. **Pronunciation Dictionaries in the Dashboard**: The Assistants view now supports creating new [pronunciation dictionaries](https://docs.vapi.ai/assistants/pronunciation-dictionaries) directly from the dashboard.
+
+4. **Phone Number Fixes**: Improvements to phone number creation and listing.
+    - The Phone Numbers list no longer breaks on rows with no number or SIP URI.
+    - Creating a phone number now validates its Vapi identifier up front.


### PR DESCRIPTION
Adds the weekly What's New entry for the week of June 1, 2026:

- xAI STT and TTS available as assistant providers
- Vapi Voices v2 model upgrade (~50% lower cost, opt-in via `version: 2`)
- Pronunciation dictionary creation from the Assistants view
- Phone number fixes (list no longer breaks on empty rows; Vapi identifier validated up front)

🤖 Generated with [Claude Code](https://claude.com/claude-code)