### PR TITLE
docs: reorder documentation sidebar and make top-level groups open-by…

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -101,6 +101,7 @@ navigation:
   - tab: documentation
     layout:
       - section: Get started
+        collapsed: open-by-default
         contents:
           - page: Introduction
             icon: fa-light fa-info-circle
@@ -123,6 +124,7 @@ navigation:
             path: cli/overview.mdx
 
       - section: Assistants
+        collapsed: open-by-default
         contents:
           # Removed dedicated introduction; Quickstart is the landing
           - page: Quickstart
@@ -284,112 +286,8 @@ navigation:
                 path: assistants/examples/multilingual-agent.mdx
                 icon: fa-light fa-globe
 
-      - section: Observability
-        contents:
-          - section: Evals
-            icon: fa-light fa-clipboard-check
-            contents:
-              - page: Quickstart
-                path: observability/evals-quickstart.mdx
-                icon: fa-light fa-clipboard-check
-              - page: Advanced
-                path: observability/evals-advanced.mdx
-                icon: fa-light fa-clipboard-check
-          - section: Simulations
-            icon: fa-light fa-flask-vial
-            availability: pre-release
-            contents:
-              - page: Quickstart
-                path: observability/simulations-quickstart.mdx
-                icon: fa-light fa-rocket
-              - page: Advanced
-                path: observability/simulations-advanced.mdx
-                icon: fa-light fa-flask-vial
-          - page: Boards
-            path: observability/boards-quickstart.mdx
-            icon: fa-light fa-chart-line
-          - section: Structured outputs
-            icon: fa-light fa-database
-            contents:
-              - page: Quickstart
-                path: assistants/structured-outputs-quickstart.mdx
-                icon: fa-light fa-rocket
-              - page: Examples
-                path: assistants/structured-outputs-examples.mdx
-                icon: fa-light fa-code
-          - section: Scorecard
-            icon: fa-light fa-star
-            contents:
-              - page: Quickstart
-                path: observability/scorecard-quickstart.mdx
-                icon: fa-light fa-rocket
-          - section: Monitoring
-            icon: fa-light fa-bell
-            contents:
-              - page: Quickstart
-                path: observability/monitoring-quickstart.mdx
-                icon: fa-light fa-rocket
-
-      - section: Squads
-        contents:
-          - page: Quickstart
-            path: squads-example.mdx
-            icon: fa-light fa-bolt-lightning
-          - page: Overview
-            path: squads.mdx
-            icon: fa-light fa-eye
-          - page: Handoff tool
-            path: squads/handoff.mdx
-            icon: fa-light fa-hand-holding-hand
-          - page: Passing data between assistants
-            path: squads/passing-data-between-assistants.mdx
-            icon: fa-light fa-share-nodes
-          - section: Examples
-            icon: fa-light fa-code
-            contents:
-              - page: Clinic triage & scheduling (handoff tool)
-                path: squads/examples/clinic-triage-scheduling-handoff-tool.mdx
-              - page: Clinic triage & scheduling
-                path: squads/examples/clinic-triage-scheduling.mdx
-              - page: E-commerce order management
-                path: squads/examples/ecommerce-order-management.mdx
-              - page: Property management routing
-                path: squads/examples/property-management.mdx
-              - page: Multilingual support
-                path: squads/examples/multilingual-support.mdx
-              - page: Silent handoffs
-                path: squads/silent-handoffs.mdx
-                icon: fa-light fa-arrow-right-arrow-left
-
-      - section: Best practices
-        contents:
-          - page: Prompting guide
-            path: prompting-guide.mdx
-            icon: fa-light fa-pen-to-square
-          - page: Debugging voice agents
-            path: debugging.mdx
-            icon: fa-light fa-bug
-          - page: Enterprise environments (DEV/UAT/PROD)
-            path: enterprise/dev-uat-prod.mdx
-            icon: fa-light fa-diagram-project
-          - page: IVR navigation
-            path: ivr-navigation.mdx
-            icon: fa-light fa-phone-office
-          - section: Testing
-            collapsed: true
-            icon: fa-light fa-clipboard-check
-            contents:
-              - page: Test suites
-                path: test/test-suites.mdx
-                icon: fa-light fa-check
-              - page: Chat testing
-                path: test/chat-testing.mdx
-                icon: fa-light fa-message
-              - page: Voice testing
-                path: test/voice-testing.mdx
-                icon: fa-light fa-volume-high
-
       - section: Phone numbers
+        collapsed: open-by-default
         contents:
           - page: Free Vapi number
             path: phone-numbers/free-telephony.mdx
@@ -432,6 +330,7 @@ navigation:
             icon: fa-light fa-webhook
 
       - section: Calls
+        collapsed: open-by-default
         path: phone-calling.mdx
         contents:
           - section: Place calls
@@ -488,6 +387,7 @@ navigation:
           # Squads moved to top-level section
 
       - section: Outbound Campaigns
+        collapsed: open-by-default
         contents:
           - page: Quickstart
             path: outbound-campaigns/quickstart.mdx
@@ -497,6 +397,7 @@ navigation:
             icon: fa-light fa-eye
 
       - section: Chat
+        collapsed: open-by-default
         contents:
           - page: Quickstart
             path: chat/quickstart.mdx
@@ -523,23 +424,8 @@ navigation:
             path: chat/web-widget.mdx
             icon: fa-light fa-window-maximize
 
-      - section: Webhooks
-        collapsed: true
-        icon: fa-light fa-webhook
-        path: server-url.mdx
-        contents:
-          - page: Setting server URLs
-            path: server-url/setting-server-urls.mdx
-          - page: Server events
-            path: server-url/events.mdx
-          - page: Spam call rejection
-            path: server-url/spam-call-rejection.mdx
-          - page: Developing locally
-            path: server-url/developing-locally.mdx
-          - page: Server authentication
-            path: server-url/server-authentication.mdx
-
       - section: Workflows
+        collapsed: open-by-default
         contents:
           - page: Quickstart
             path: workflows/quickstart.mdx
@@ -569,8 +455,132 @@ navigation:
                 path: workflows/examples/multilingual-support.mdx
                 icon: fa-light fa-globe
 
+      - section: Squads
+        collapsed: open-by-default
+        contents:
+          - page: Quickstart
+            path: squads-example.mdx
+            icon: fa-light fa-bolt-lightning
+          - page: Overview
+            path: squads.mdx
+            icon: fa-light fa-eye
+          - page: Handoff tool
+            path: squads/handoff.mdx
+            icon: fa-light fa-hand-holding-hand
+          - page: Passing data between assistants
+            path: squads/passing-data-between-assistants.mdx
+            icon: fa-light fa-share-nodes
+          - section: Examples
+            icon: fa-light fa-code
+            contents:
+              - page: Clinic triage & scheduling (handoff tool)
+                path: squads/examples/clinic-triage-scheduling-handoff-tool.mdx
+              - page: Clinic triage & scheduling
+                path: squads/examples/clinic-triage-scheduling.mdx
+              - page: E-commerce order management
+                path: squads/examples/ecommerce-order-management.mdx
+              - page: Property management routing
+                path: squads/examples/property-management.mdx
+              - page: Multilingual support
+                path: squads/examples/multilingual-support.mdx
+              - page: Silent handoffs
+                path: squads/silent-handoffs.mdx
+                icon: fa-light fa-arrow-right-arrow-left
+
+      - section: Webhooks
+        collapsed: open-by-default
+        icon: fa-light fa-webhook
+        path: server-url.mdx
+        contents:
+          - page: Setting server URLs
+            path: server-url/setting-server-urls.mdx
+          - page: Server events
+            path: server-url/events.mdx
+          - page: Spam call rejection
+            path: server-url/spam-call-rejection.mdx
+          - page: Developing locally
+            path: server-url/developing-locally.mdx
+          - page: Server authentication
+            path: server-url/server-authentication.mdx
+
+      - section: Observability
+        collapsed: open-by-default
+        contents:
+          - section: Evals
+            icon: fa-light fa-clipboard-check
+            contents:
+              - page: Quickstart
+                path: observability/evals-quickstart.mdx
+                icon: fa-light fa-clipboard-check
+              - page: Advanced
+                path: observability/evals-advanced.mdx
+                icon: fa-light fa-clipboard-check
+          - section: Simulations
+            icon: fa-light fa-flask-vial
+            availability: pre-release
+            contents:
+              - page: Quickstart
+                path: observability/simulations-quickstart.mdx
+                icon: fa-light fa-rocket
+              - page: Advanced
+                path: observability/simulations-advanced.mdx
+                icon: fa-light fa-flask-vial
+          - page: Boards
+            path: observability/boards-quickstart.mdx
+            icon: fa-light fa-chart-line
+          - section: Structured outputs
+            icon: fa-light fa-database
+            contents:
+              - page: Quickstart
+                path: assistants/structured-outputs-quickstart.mdx
+                icon: fa-light fa-rocket
+              - page: Examples
+                path: assistants/structured-outputs-examples.mdx
+                icon: fa-light fa-code
+          - section: Scorecard
+            icon: fa-light fa-star
+            contents:
+              - page: Quickstart
+                path: observability/scorecard-quickstart.mdx
+                icon: fa-light fa-rocket
+          - section: Monitoring
+            icon: fa-light fa-bell
+            contents:
+              - page: Quickstart
+                path: observability/monitoring-quickstart.mdx
+                icon: fa-light fa-rocket
+
+      - section: Best practices
+        collapsed: open-by-default
+        contents:
+          - page: Prompting guide
+            path: prompting-guide.mdx
+            icon: fa-light fa-pen-to-square
+          - page: Debugging voice agents
+            path: debugging.mdx
+            icon: fa-light fa-bug
+          - page: Enterprise environments (DEV/UAT/PROD)
+            path: enterprise/dev-uat-prod.mdx
+            icon: fa-light fa-diagram-project
+          - page: IVR navigation
+            path: ivr-navigation.mdx
+            icon: fa-light fa-phone-office
+          - section: Testing
+            collapsed: true
+            icon: fa-light fa-clipboard-check
+            contents:
+              - page: Test suites
+                path: test/test-suites.mdx
+                icon: fa-light fa-check
+              - page: Chat testing
+                path: test/chat-testing.mdx
+                icon: fa-light fa-message
+              - page: Voice testing
+                path: test/voice-testing.mdx
+                icon: fa-light fa-volume-high
+
       - section: Resources
-        collapsed: false
+        collapsed: open-by-default
         contents:
           - page: FAQ
             path: faq.mdx


### PR DESCRIPTION
## Description

- Reorder doc-tab sections: Get started, Assistants, Phone numbers, Calls, Outbound Campaigns, Chat, Workflows, Squads, Webhooks, Observability, Best practices, Resources
- Set collapsed: open-by-default on all top-level documentation groups (expanded on load, collapsible). No page content changed.
  
## Testing Steps

- [ X] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ X] Ensure that the changed pages and code snippets work
