### PR TITLE
docs: update Emma voice age from 20s to 30s

### DIFF
--- a/fern/providers/voice/vapi-voices.mdx
+++ b/fern/providers/voice/vapi-voices.mdx
@@ -65,7 +65,7 @@ These voices are fully supported and recommended for new assistants. The voices 
 ### Emma <span style={{color: '#22c55e', fontWeight: 'bold', fontSize: '0.75em', verticalAlign: 'super'}}>New</span> <span style={{color: '#3b82f6', fontWeight: 'bold', fontSize: '0.75em', verticalAlign: 'super'}}>V2</span>
 - **Gender**: Female
 - **Accent**: Asian American
-- **Age**: 20s
+- **Age**: 30s
 - **Characteristics**: Realistic, warm, conversational
 - **Sample Audio**: <audio controls src="/static/audio/emma-sample.wav">Your browser does not support the audio element.</audio>
 


### PR DESCRIPTION
Updates the Emma voice listing to reflect an age range of **30s** (previously 20s).

File: `fern/providers/voice/vapi-voices.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)