### PR TITLE
Removed Emotion Detection section from how-vapi-works

### DIFF
--- a/fern/how-vapi-works.mdx
+++ b/fern/how-vapi-works.mdx
@@ -62,12 +62,6 @@ They're not considered interruptions, they're just used to let the speaker know 
 
 A backchannel cue used at the wrong moment can derail a user's statement. Vapi uses a proprietary fusion audio text model to determine the best moment to backchannel and to decide which backchannel cue is most appropriate to use.
 
-### Emotion Detection
-
-How a person says something is just as important as what they're saying. So we've trained a real-time audio model to extract the emotional inflection of the user's statement.
-
-This emotional information is then fed into the LLM, so knows to behave differently if the user is angry, annoyed, or confused.
-
 ### Filler Injection
 
 The output of LLMs tends to be formal, and not conversational. People speak with phrases like "umm", "ahh", "i mean", "like", "so", etc.


### PR DESCRIPTION
Removed the section on Emotion Detection from the document as it's deprecated.

## Description

The emotion detection feature has been deprecated, so removed it from "how vapi works" to keep the docs updated for customers.