### PR TITLE
fix: correct EU SIP allowlist docs

### DIFF
--- a/fern/advanced/sip/sip-chime.mdx
+++ b/fern/advanced/sip/sip-chime.mdx
@@ -44,14 +44,16 @@ Save the **Outbound host name** from the Voice Connector details — you need it
 
 Navigate to the **Termination** tab of your Voice Connector and enable it.
 
-Add Vapi's static IP addresses to the allowed host list:
+Add Vapi's static IP addresses for your Vapi region to the allowed host list:
 
 ![Whitelist IP 1](../../static/images/sip/sip-chime-ip-1.png)
 
 ![Whitelist IP 2](../../static/images/sip/sip-chime-ip-2.png)
 
-- `44.229.228.186/32`
-- `44.238.177.138/32`
+| Region | IP addresses |
+| --- | --- |
+| US | `44.229.228.186/32`, `44.238.177.138/32` |
+| EU | `63.182.83.170/32` |
 
 </Step>
 
@@ -194,7 +196,7 @@ For inbound calls, a caller dials your Chime SDK phone number. The Voice Connect
 graph LR
   A[Caller] --> B[Chime Phone Number]
   B --> C[Voice Connector]
-  C --> D[sip.vapi.ai]
+  C --> D[Regional Vapi SIP host]
   D --> E[Vapi AI Assistant]
 ```
 
@@ -276,9 +278,10 @@ Navigate to your Voice Connector's **Origination** tab and set **Origination sta
 
 ![Enable Origination](../../static/images/sip/sip-chime-enable-origination.png)
 
-Click **New** to add an inbound route pointing to Vapi's SIP server:
+Click **New** to add an inbound route pointing to Vapi's SIP server for your region:
 
-- **Host:** `YOUR_CREDENTIAL_ID.sip.vapi.ai`
+- **Host (US):** `YOUR_CREDENTIAL_ID.sip.vapi.ai`
+- **Host (EU):** `YOUR_CREDENTIAL_ID.sip.eu.vapi.ai`
 - **Port:** `5061` (for encrypted connections)
 - **Protocol:** TCP
 
@@ -288,7 +291,7 @@ Click **New** to add an inbound route pointing to Vapi's SIP server:
 
 <Step title="Test the integration">
 
-Call your Chime SDK phone number from any phone. The call routes through the Voice Connector's origination settings to `sip.vapi.ai`, where your Vapi assistant answers.
+Call your Chime SDK phone number from any phone. The call routes through the Voice Connector's origination settings to your regional Vapi SIP host, where your Vapi assistant answers.
 
 To debug issues, enable **SIP logging** on the Voice Connector (under the **Logging** tab) for detailed SIP message traces.
 

--- a/fern/advanced/sip/sip-networking.mdx
+++ b/fern/advanced/sip/sip-networking.mdx
@@ -25,21 +25,20 @@ The table below summarizes every IP address, port, and protocol you need to allo
 | Traffic type | Region | Hostname | IP addresses | Ports | Protocol | Direction |
 | --- | --- | --- | --- | --- | --- | --- |
 | SIP signalling | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5060` | UDP | Bidirectional |
-| SIP signalling | EU | `sip.eu.vapi.ai` | `44.233.34.47`, `44.233.34.48` | `5060` | UDP | Bidirectional |
+| SIP signalling | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `5060` | UDP/TCP | Bidirectional |
 | SIP signalling (TLS) | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5061` | TLS | Bidirectional |
-| SIP signalling (TLS) | EU | `sip.eu.vapi.ai` | `44.233.34.47`, `44.233.34.48` | `5061` | TLS | Bidirectional |
 | RTP media | All regions | N/A | No static IPs (dynamic) | `40000`-`60000` | UDP | Bidirectional |
 
-Use your region's SIP hostname when configuring SIP URIs or SIP peers. If your firewall or SIP provider requires IP-based allowlisting, add the signalling IP addresses for your region explicitly.
+Use your region's SIP hostname when configuring SIP URIs or SIP peers. If your firewall or SIP provider requires IP-based allowlisting, add the signalling IP addresses for your region explicitly. For EU TLS/SIPS requirements, contact support before allowlisting port `5061`.
 
 ## SIP signalling
 
-Vapi's SIP infrastructure uses two static IP addresses for signalling traffic in each region:
+Vapi's SIP infrastructure uses static IP addresses for signalling traffic in each region:
 
 | Region | Hostname | IP addresses |
 | --- | --- | --- |
 | US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32` |
-| EU | `sip.eu.vapi.ai` | `44.233.34.47/32`, `44.233.34.48/32` |
+| EU | `sip.eu.vapi.ai` | `63.182.83.170/32` |
 
 These are the public IPs of Vapi's SBC (Session Border Controller) nodes. All SIP `INVITE`, `REGISTER`, `BYE`, and other signalling messages originate from and are received at the addresses for your region.
 
@@ -47,17 +46,17 @@ These are the public IPs of Vapi's SBC (Session Border Controller) nodes. All SI
 
 | Port | Protocol | Use case |
 | --- | --- | --- |
-| **5060** | UDP | Default SIP signalling |
-| **5061** | TLS | SIP over TLS (SIPS) for encrypted signalling |
+| **5060** | UDP/TCP | Default SIP signalling. EU traffic may use TCP on this port. |
+| **5061** | TLS | SIP over TLS (SIPS) for US signalling. Contact support before using TLS/SIPS in the EU. |
 
-Use port **5060** unless your provider or security requirements mandate encrypted signalling, in which case use port **5061** with TLS.
+Use port **5060** unless your provider or security requirements mandate encrypted signalling. For US TLS/SIPS, use port **5061** with TLS. For EU TLS/SIPS requirements, contact support before allowlisting port `5061`.
 
 ### Hostnames and allowlisting
 
 Configure your SIP client or PBX to point to the hostname for your region. For firewall rules and carrier allowlists, use the static signalling IP addresses listed for your region.
 
 <Tip>
-  Allowlist both IP addresses for your region explicitly. DNS A records may not match every static signalling IP that Vapi can use for carrier or firewall allowlisting.
+  Allowlist every IP address for your region explicitly. DNS A records may not match every static signalling IP that Vapi can use for carrier or firewall allowlisting.
 </Tip>
 
 ## SIP media (RTP)
@@ -86,7 +85,7 @@ Vapi uses **UDP ports 40000 through 60000** for RTP media traffic.
 
 ## Firewall rules
 
-Configure your firewall to allow the following traffic. Both SIP signalling IP addresses for your region must be allowlisted, as Vapi may use either one for any given call. For RTP media, allow traffic on the full port range without IP restrictions since Vapi uses dynamic IPs for media.
+Configure your firewall to allow the following traffic. Every SIP signalling IP address for your region must be allowlisted. For RTP media, allow traffic on the full port range without IP restrictions since Vapi uses dynamic IPs for media.
 
 ### Inbound rules (traffic from Vapi to your network)
 
@@ -95,9 +94,8 @@ Allow these if your SIP provider or PBX needs to receive traffic from Vapi:
 | Rule | Region | Source IP | Destination | Port(s) | Protocol |
 | --- | --- | --- | --- | --- | --- |
 | SIP signalling | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5060` | UDP |
-| SIP signalling | EU | `44.233.34.47`, `44.233.34.48` | Your SIP server | `5060` | UDP |
+| SIP signalling | EU | `63.182.83.170` | Your SIP server | `5060` | UDP/TCP |
 | SIP signalling (TLS) | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5061` | TLS |
-| SIP signalling (TLS) | EU | `44.233.34.47`, `44.233.34.48` | Your SIP server | `5061` | TLS |
 | RTP media | All regions | Any (dynamic) | Your media server | `40000`-`60000` | UDP |
 
 ### Outbound rules (traffic from your network to Vapi)
@@ -107,20 +105,19 @@ Allow these if your firewall restricts outbound connections:
 | Rule | Region | Source | Destination IP | Port(s) | Protocol |
 | --- | --- | --- | --- | --- | --- |
 | SIP signalling | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5060` | UDP |
-| SIP signalling | EU | Your SIP server | `44.233.34.47`, `44.233.34.48` | `5060` | UDP |
+| SIP signalling | EU | Your SIP server | `63.182.83.170` | `5060` | UDP/TCP |
 | SIP signalling (TLS) | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5061` | TLS |
-| SIP signalling (TLS) | EU | Your SIP server | `44.233.34.47`, `44.233.34.48` | `5061` | TLS |
 | RTP media | All regions | Your media server | Any (dynamic) | `40000`-`60000` | UDP |
 
 <Warning>
-  Both SIP signalling IP addresses for your region must be allowed in your firewall rules. Vapi may use either address for signalling on any given call. Missing one address can cause intermittent call failures. For RTP media, since Vapi uses dynamic IPs, configure your firewall to allow the full port range (`40000`-`60000` UDP) without restricting by source or destination IP.
+  Allow every SIP signalling IP address for your region in your firewall rules. For RTP media, since Vapi uses dynamic IPs, configure your firewall to allow the full port range (`40000`-`60000` UDP) without restricting by source or destination IP. Contact support if you need a stricter media firewall policy.
 </Warning>
 
 ## FAQ
 
 <AccordionGroup>
   <Accordion title="Can I use DNS instead of IP addresses in my firewall rules?">
-    Use your region's hostname for SIP URI and peer configuration. For IP-based firewall rules, add both static signalling IP addresses for your region explicitly. DNS-based firewall rules depend on TTL and caching behavior, and DNS A records may not match every static signalling IP that Vapi can use for allowlisting. RTP media uses dynamic IPs that cannot be resolved via DNS.
+    Use your region's hostname for SIP URI and peer configuration. For IP-based firewall rules, add the static signalling IP addresses for your region explicitly. DNS-based firewall rules depend on TTL and caching behavior, and DNS A records may not match every static signalling IP that Vapi can use for allowlisting. RTP media uses dynamic IPs that cannot be resolved via DNS.
   </Accordion>
   <Accordion title="Do I need to open the full 40000-60000 port range?">
     Yes. Vapi's RTP stack dynamically allocates ports within this range for each call. You cannot predict which specific port a given call will use, so the entire range must be open for reliable media flow.
@@ -129,7 +126,7 @@ Allow these if your firewall restricts outbound connections:
     No. Vapi's SIP signalling uses static IP addresses for each region, but RTP media does not use static IP addresses. Media source IPs are dynamically assigned and may vary between calls.
   </Accordion>
   <Accordion title="Does Vapi support SRTP (encrypted media)?">
-    Vapi supports TLS for SIP signalling on port 5061. For encrypted media (SRTP), configure your SIP trunk gateway with the `tls/srtp` outbound protocol option. See the [gateway configuration reference](/advanced/sip/troubleshoot-sip-trunk-credential-errors#gateway-configuration-reference) for details.
+    Vapi supports TLS for US SIP signalling on port 5061. For EU TLS/SIPS requirements, contact support before allowlisting port `5061`. For encrypted media (SRTP), configure your SIP trunk gateway with the `tls/srtp` outbound protocol option. See the [gateway configuration reference](/advanced/sip/troubleshoot-sip-trunk-credential-errors#gateway-configuration-reference) for details.
   </Accordion>
 </AccordionGroup>
 

--- a/fern/advanced/sip/sip-networking.mdx
+++ b/fern/advanced/sip/sip-networking.mdx
@@ -27,10 +27,11 @@ The table below summarizes every IP address, port, and protocol you need to allo
 | SIP signalling | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5060` | UDP | Bidirectional |
 | SIP signalling | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `5060` | UDP/TCP | Bidirectional |
 | SIP signalling (TLS) | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5061` | TLS | Bidirectional |
+| SIP signalling (TLS) | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `5061` | TLS | Bidirectional |
 | RTP media | US | N/A | No static IPs (dynamic) | `40000`-`60000` | UDP | Bidirectional |
-| RTP media | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `40000`-`60000` | UDP | Bidirectional |
+| RTP media | EU | N/A | `63.182.83.170` | `40000`-`60000` | UDP | Bidirectional |
 
-Use your region's SIP hostname when configuring SIP URIs or SIP peers. If your firewall or SIP provider requires IP-based allowlisting, add the signalling and media IP addresses for your region explicitly. EU SIP over TLS on port `5061` is not currently configured.
+Use your region's SIP hostname when configuring SIP URIs or SIP peers. If your firewall or SIP provider requires IP-based allowlisting, add the static signalling IP addresses for your region. For media, EU traffic can be allowlisted to `63.182.83.170`; US media uses dynamic source IPs and should be allowed by UDP port range.
 
 ## SIP signalling
 
@@ -48,9 +49,9 @@ These are the public IPs of Vapi's SBC (Session Border Controller) nodes. All SI
 | Port | Protocol | Use case |
 | --- | --- | --- |
 | **5060** | UDP/TCP | Default SIP signalling. EU traffic may use TCP on this port. |
-| **5061** | TLS | SIP over TLS (SIPS) for US signalling only. EU SIP over TLS is not currently configured. |
+| **5061** | TLS | SIP over TLS (SIPS) signalling. |
 
-Use port **5060** unless your provider or security requirements mandate encrypted signalling. For US TLS/SIPS, use port **5061** with TLS. Do not allowlist EU port `5061` for SIP signalling unless Vapi confirms TLS support for your deployment.
+Use port **5060** unless your provider or security requirements mandate encrypted signalling. For TLS/SIPS in either region, use port **5061** with TLS.
 
 ### Hostnames and allowlisting
 
@@ -104,6 +105,7 @@ Allow these if your SIP provider or PBX needs to receive traffic from Vapi:
 | SIP signalling | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5060` | UDP |
 | SIP signalling | EU | `63.182.83.170` | Your SIP server | `5060` | UDP/TCP |
 | SIP signalling (TLS) | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5061` | TLS |
+| SIP signalling (TLS) | EU | `63.182.83.170` | Your SIP server | `5061` | TLS |
 | RTP media | US | Any (dynamic) | Your media server | `40000`-`60000` | UDP |
 | RTP media | EU | `63.182.83.170` | Your media server | `40000`-`60000` | UDP |
 
@@ -116,6 +118,7 @@ Allow these if your firewall restricts outbound connections:
 | SIP signalling | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5060` | UDP |
 | SIP signalling | EU | Your SIP server | `63.182.83.170` | `5060` | UDP/TCP |
 | SIP signalling (TLS) | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5061` | TLS |
+| SIP signalling (TLS) | EU | Your SIP server | `63.182.83.170` | `5061` | TLS |
 | RTP media | US | Your media server | Any (dynamic) | `40000`-`60000` | UDP |
 | RTP media | EU | Your media server | `63.182.83.170` | `40000`-`60000` | UDP |
 
@@ -136,7 +139,7 @@ Allow these if your firewall restricts outbound connections:
     It depends on the region. In the EU, SIP signalling and RTP media both use `63.182.83.170`. In the US, SIP signalling uses static IP addresses, but RTP media source IPs are dynamically assigned and may vary between calls.
   </Accordion>
   <Accordion title="Does Vapi support SRTP (encrypted media)?">
-    Vapi supports TLS for US SIP signalling on port 5061. EU SIP over TLS on port `5061` is not currently configured. For encrypted media (SRTP), configure your SIP trunk gateway with the `tls/srtp` outbound protocol option. See the [gateway configuration reference](/advanced/sip/troubleshoot-sip-trunk-credential-errors#gateway-configuration-reference) for details.
+    Vapi supports TLS for SIP signalling on port 5061 in both US and EU regions. For encrypted media (SRTP), configure your SIP trunk gateway with the `tls/srtp` outbound protocol option. See the [gateway configuration reference](/advanced/sip/troubleshoot-sip-trunk-credential-errors#gateway-configuration-reference) for details.
   </Accordion>
   <Accordion title="What do SIP 403 and 404 responses mean?">
     A `403 Forbidden` response with `X-Reason: Invalid credentials` usually means IP allowlisting or authentication failed. A `404 Not Found` response usually means Vapi could not find a matching account or called number for the request.

--- a/fern/advanced/sip/sip-networking.mdx
+++ b/fern/advanced/sip/sip-networking.mdx
@@ -11,7 +11,7 @@ When you integrate a SIP trunk with Vapi, your firewall and network infrastructu
 **In this reference, you'll find:**
 
 - All IP addresses and ports used by Vapi for SIP signalling
-- RTP media port ranges, directionality details, and dynamic IP behavior
+- RTP media port ranges, directionality details, and regional IP behavior
 - Recommended firewall rules for inbound and outbound traffic
 
 <Note>
@@ -27,9 +27,10 @@ The table below summarizes every IP address, port, and protocol you need to allo
 | SIP signalling | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5060` | UDP | Bidirectional |
 | SIP signalling | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `5060` | UDP/TCP | Bidirectional |
 | SIP signalling (TLS) | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5061` | TLS | Bidirectional |
-| RTP media | All regions | N/A | No static IPs (dynamic) | `40000`-`60000` | UDP | Bidirectional |
+| RTP media | US | N/A | No static IPs (dynamic) | `40000`-`60000` | UDP | Bidirectional |
+| RTP media | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `40000`-`60000` | UDP | Bidirectional |
 
-Use your region's SIP hostname when configuring SIP URIs or SIP peers. If your firewall or SIP provider requires IP-based allowlisting, add the signalling IP addresses for your region explicitly. For EU TLS/SIPS requirements, contact support before allowlisting port `5061`.
+Use your region's SIP hostname when configuring SIP URIs or SIP peers. If your firewall or SIP provider requires IP-based allowlisting, add the signalling and media IP addresses for your region explicitly. EU SIP over TLS on port `5061` is not currently configured.
 
 ## SIP signalling
 
@@ -47,24 +48,31 @@ These are the public IPs of Vapi's SBC (Session Border Controller) nodes. All SI
 | Port | Protocol | Use case |
 | --- | --- | --- |
 | **5060** | UDP/TCP | Default SIP signalling. EU traffic may use TCP on this port. |
-| **5061** | TLS | SIP over TLS (SIPS) for US signalling. Contact support before using TLS/SIPS in the EU. |
+| **5061** | TLS | SIP over TLS (SIPS) for US signalling only. EU SIP over TLS is not currently configured. |
 
-Use port **5060** unless your provider or security requirements mandate encrypted signalling. For US TLS/SIPS, use port **5061** with TLS. For EU TLS/SIPS requirements, contact support before allowlisting port `5061`.
+Use port **5060** unless your provider or security requirements mandate encrypted signalling. For US TLS/SIPS, use port **5061** with TLS. Do not allowlist EU port `5061` for SIP signalling unless Vapi confirms TLS support for your deployment.
 
 ### Hostnames and allowlisting
 
-Configure your SIP client or PBX to point to the hostname for your region. For firewall rules and carrier allowlists, use the static signalling IP addresses listed for your region.
+Configure your SIP client or PBX to point to the hostname for your region. For firewall rules and carrier allowlists, use the static IP addresses listed for your region. In the EU, `sip.eu.vapi.ai` currently resolves to `63.182.83.170`.
 
 <Tip>
-  Allowlist every IP address for your region explicitly. DNS A records may not match every static signalling IP that Vapi can use for carrier or firewall allowlisting.
+  Allowlist every IP address for your region explicitly. DNS A records may not match every static IP that Vapi can use for carrier or firewall allowlisting.
 </Tip>
+
+<Warning>
+  Do not use `sip-web.eu.vapi.ai` for SIP signalling or media. It is used for portal and API traffic and resolves through Cloudflare/WAF, not to Vapi's SIP infrastructure.
+</Warning>
 
 ## SIP media (RTP)
 
-Vapi does not use static IP addresses for RTP media (voice audio). The media source IP addresses are dynamically assigned and may change between calls. Because of this, you should not rely on allowlisting specific IPs for RTP media traffic.
+RTP media IP behavior depends on your region:
+
+- **US:** Vapi does not use static IP addresses for RTP media. Media source IPs are dynamically assigned and may change between calls.
+- **EU:** RTP media uses the same static public IP as SIP signalling: `63.182.83.170`.
 
 <Warning>
-  Unlike SIP signalling, RTP media does **not** originate from a fixed set of IP addresses. Your firewall rules for RTP media should allow traffic based on port ranges rather than specific source IPs.
+  For US RTP media, allow traffic based on port ranges rather than specific source IPs. For EU RTP media, allowlist `63.182.83.170` with the full UDP port range.
 </Warning>
 
 ### Port range
@@ -85,7 +93,7 @@ Vapi uses **UDP ports 40000 through 60000** for RTP media traffic.
 
 ## Firewall rules
 
-Configure your firewall to allow the following traffic. Every SIP signalling IP address for your region must be allowlisted. For RTP media, allow traffic on the full port range without IP restrictions since Vapi uses dynamic IPs for media.
+Configure your firewall to allow the following traffic. Every SIP signalling IP address for your region must be allowlisted. For RTP media, allow traffic on the full port range. US media uses dynamic IPs; EU media uses `63.182.83.170`.
 
 ### Inbound rules (traffic from Vapi to your network)
 
@@ -96,7 +104,8 @@ Allow these if your SIP provider or PBX needs to receive traffic from Vapi:
 | SIP signalling | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5060` | UDP |
 | SIP signalling | EU | `63.182.83.170` | Your SIP server | `5060` | UDP/TCP |
 | SIP signalling (TLS) | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5061` | TLS |
-| RTP media | All regions | Any (dynamic) | Your media server | `40000`-`60000` | UDP |
+| RTP media | US | Any (dynamic) | Your media server | `40000`-`60000` | UDP |
+| RTP media | EU | `63.182.83.170` | Your media server | `40000`-`60000` | UDP |
 
 ### Outbound rules (traffic from your network to Vapi)
 
@@ -107,26 +116,30 @@ Allow these if your firewall restricts outbound connections:
 | SIP signalling | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5060` | UDP |
 | SIP signalling | EU | Your SIP server | `63.182.83.170` | `5060` | UDP/TCP |
 | SIP signalling (TLS) | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5061` | TLS |
-| RTP media | All regions | Your media server | Any (dynamic) | `40000`-`60000` | UDP |
+| RTP media | US | Your media server | Any (dynamic) | `40000`-`60000` | UDP |
+| RTP media | EU | Your media server | `63.182.83.170` | `40000`-`60000` | UDP |
 
 <Warning>
-  Allow every SIP signalling IP address for your region in your firewall rules. For RTP media, since Vapi uses dynamic IPs, configure your firewall to allow the full port range (`40000`-`60000` UDP) without restricting by source or destination IP. Contact support if you need a stricter media firewall policy.
+  Allow every SIP signalling IP address for your region in your firewall rules. For RTP media, configure your firewall to allow the full port range (`40000`-`60000` UDP). US RTP media uses dynamic IPs. EU RTP media uses `63.182.83.170`. Contact support if you need a stricter media firewall policy.
 </Warning>
 
 ## FAQ
 
 <AccordionGroup>
   <Accordion title="Can I use DNS instead of IP addresses in my firewall rules?">
-    Use your region's hostname for SIP URI and peer configuration. For IP-based firewall rules, add the static signalling IP addresses for your region explicitly. DNS-based firewall rules depend on TTL and caching behavior, and DNS A records may not match every static signalling IP that Vapi can use for allowlisting. RTP media uses dynamic IPs that cannot be resolved via DNS.
+    Use your region's hostname for SIP URI and peer configuration. For IP-based firewall rules, add the static IP addresses for your region explicitly. DNS-based firewall rules depend on TTL and caching behavior, and DNS A records may not match every static IP that Vapi can use for allowlisting. US RTP media uses dynamic IPs that cannot be resolved via DNS. EU RTP media uses `63.182.83.170`.
   </Accordion>
   <Accordion title="Do I need to open the full 40000-60000 port range?">
     Yes. Vapi's RTP stack dynamically allocates ports within this range for each call. You cannot predict which specific port a given call will use, so the entire range must be open for reliable media flow.
   </Accordion>
   <Accordion title="Are the signalling and media IPs the same?">
-    No. Vapi's SIP signalling uses static IP addresses for each region, but RTP media does not use static IP addresses. Media source IPs are dynamically assigned and may vary between calls.
+    It depends on the region. In the EU, SIP signalling and RTP media both use `63.182.83.170`. In the US, SIP signalling uses static IP addresses, but RTP media source IPs are dynamically assigned and may vary between calls.
   </Accordion>
   <Accordion title="Does Vapi support SRTP (encrypted media)?">
-    Vapi supports TLS for US SIP signalling on port 5061. For EU TLS/SIPS requirements, contact support before allowlisting port `5061`. For encrypted media (SRTP), configure your SIP trunk gateway with the `tls/srtp` outbound protocol option. See the [gateway configuration reference](/advanced/sip/troubleshoot-sip-trunk-credential-errors#gateway-configuration-reference) for details.
+    Vapi supports TLS for US SIP signalling on port 5061. EU SIP over TLS on port `5061` is not currently configured. For encrypted media (SRTP), configure your SIP trunk gateway with the `tls/srtp` outbound protocol option. See the [gateway configuration reference](/advanced/sip/troubleshoot-sip-trunk-credential-errors#gateway-configuration-reference) for details.
+  </Accordion>
+  <Accordion title="What do SIP 403 and 404 responses mean?">
+    A `403 Forbidden` response with `X-Reason: Invalid credentials` usually means IP allowlisting or authentication failed. A `404 Not Found` response usually means Vapi could not find a matching account or called number for the request.
   </Accordion>
 </AccordionGroup>
 

--- a/fern/advanced/sip/sip-plivo.mdx
+++ b/fern/advanced/sip/sip-plivo.mdx
@@ -39,13 +39,12 @@ Indian phone numbers cannot be used with Plivo on Vapi due to TRAI regulations. 
         
         2. **Fill out the form:**
         - **Name:** Enter a descriptive name (for example, `VAPI-IP-Group`).
-        - **IP Address List:** Add each of the following IP addresses one at a time:
-        ```
-44.229.228.186/32
-        ```
-        ```
-44.238.177.138/32
-        ```
+        - **IP Address List:** Add each IP address for the Vapi region where your organization is hosted:
+
+        | Region | IP addresses |
+        | --- | --- |
+        | US | `44.229.228.186/32`, `44.238.177.138/32` |
+        | EU | `63.182.83.170/32` |
         3. **Click** **Create ACL** to save.
         
         ![Plivo IP Access Control List](../../static/images/sip/sip-plivo-ip-acl.png)
@@ -192,7 +191,7 @@ Indian phone numbers cannot be used with Plivo on Vapi due to TRAI regulations. 
         
         2. **Fill out the form:**
         - **Name:** Enter a descriptive name (for example, `Vapi Inbound`).
-        - **URI:** Enter this origination URI exactly: `sip.vapi.ai;transport=udp`
+        - **URI:** Enter the origination URI for your Vapi region: `sip.vapi.ai;transport=udp` for US or `sip.eu.vapi.ai;transport=udp` for EU.
         3. **Click** **Create URI** to save.
         
         ![Create New IP URI](../../static/images/sip/sip-plivo-create-new-ip-uri.png)

--- a/fern/advanced/sip/sip-telnyx.mdx
+++ b/fern/advanced/sip/sip-telnyx.mdx
@@ -24,7 +24,7 @@ Integrate your Telnyx SIP trunk with Vapi to enable your AI voice assistants to 
         - Select FQDN
         - Click "Add FQDN"
         - Select A record type
-        - Set FQDN to: `sip.vapi.ai`
+        - Set FQDN to the SIP host for your Vapi region: `sip.vapi.ai` for US or `sip.eu.vapi.ai` for EU
         - Port should be 5060 by default
       </Step>
       <Step title="Configure inbound settings">
@@ -46,7 +46,7 @@ Integrate your Telnyx SIP trunk with Vapi to enable your AI voice assistants to 
         <Info>
           You can get your Vapi SIP URI when you create a new SIP number through the **Phone Numbers** tab in the Vapi dashboard. The URI will look like:
           <br />
-          <code>sip:&lt;your-unique-id&gt;@sip.vapi.ai</code>
+          <code>sip:&lt;your-unique-id&gt;@sip.vapi.ai</code> for US or <code>sip:&lt;your-unique-id&gt;@sip.eu.vapi.ai</code> for EU
         </Info>
         *This setting modifies the SIP Invite so invites are correctly routed to your Vapi SIP URI.*
       </Step>

--- a/fern/advanced/sip/sip-trunk.mdx
+++ b/fern/advanced/sip/sip-trunk.mdx
@@ -8,12 +8,14 @@ SIP trunking replaces traditional phone lines with a virtual connection over the
 
 ## Network requirements
 
-To allow SIP signaling and media between Vapi and your SIP provider, you must allowlist the following IP addresses:
+To allow SIP signaling and media between Vapi and your SIP provider, allowlist the static IP addresses for the Vapi region where your organization is hosted:
 
-- 44.229.228.186/32
-- 44.238.177.138/32
+| Region | SIP host | Signalling IP addresses | RTP media behavior |
+| --- | --- | --- | --- |
+| US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32` | Dynamic media IPs; allow UDP ports `40000`-`60000` |
+| EU | `sip.eu.vapi.ai` | `63.182.83.170/32` | Static media IP `63.182.83.170`; allow UDP ports `40000`-`60000` |
 
-These IPs are used exclusively for SIP traffic. For the complete list of ports, RTP ranges, and firewall configuration details, see the [networking and firewall](/advanced/sip/sip-networking) reference.
+For the complete list of ports, TLS options, RTP ranges, and firewall configuration details, see the [networking and firewall](/advanced/sip/sip-networking) reference.
 
 <Warning>
 We generally don't recommend IP-based authentication for SIP trunks as it can lead to routing issues. Since our servers are shared by many customers, if your telephony provider has multiple customers using IP-based authentication, calls may be routed incorrectly. IP-based authentication works reliably only when your SIP provider offers a unique termination URI or a dedicated SIP server for each customer, as is the case with Plivo and Twilio integrations.
@@ -98,7 +100,7 @@ Vapi supports multiple SIP trunk configurations, including:
         ```
       </Step>
       <Step title="Inbound call test">
-        If inbound routing is configured, call your phone number from an external line. Ensure your provider forwards calls to the correct SIP URI (e.g., `{phoneNumber}@<credential_id>.sip.vapi.ai` for Zadarma).
+        If inbound routing is configured, call your phone number from an external line. Ensure your provider forwards calls to the correct regional SIP URI (for example, `{phoneNumber}@<credential_id>.sip.vapi.ai` for US or `{phoneNumber}@<credential_id>.sip.eu.vapi.ai` for EU).
         
         <Warning>
         Note: Please ensure that you provide all the signaling IP addresses when creating the SIP trunk. Failure to do so will prevent proper whitelisting, which may result in encountering unauthorized 401 errors for inbound calls.

--- a/fern/advanced/sip/sip-twilio.mdx
+++ b/fern/advanced/sip/sip-twilio.mdx
@@ -39,9 +39,12 @@ This guide walks you through setting up both outbound and inbound SIP trunking b
    
    ![IP Authentication](../../static/images/sip/sip-twilio-ip-authentication.png)
    
-   Whitelist Vapi's SIP server static IPs:
-   - 44.229.228.186
-   - 44.238.177.138
+   Whitelist Vapi's SIP server static IPs for the Vapi region where your organization is hosted:
+
+   | Region | SIP host | IP addresses |
+   | --- | --- | --- |
+   | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` |
+   | EU | `sip.eu.vapi.ai` | `63.182.83.170` |
    
    Ensure you whitelist the entire IP range as shown below:
    
@@ -137,7 +140,13 @@ This guide walks you through setting up both outbound and inbound SIP trunking b
    
    ![Origination Settings](../../static/images/sip/sip-twilio-origination.png)
    
-   Add your Vapi SIP URI in the following format: `sip:YOUR_PHONE_NUMBER@<credential_id>.sip.vapi.ai`, where "YOUR_PHONE_NUMBER" is your chosen SIP number that you will attach to this trunk.
+   Add your Vapi SIP URI using the SIP host for your Vapi region:
+
+   - US: `sip:YOUR_PHONE_NUMBER@<credential_id>.sip.vapi.ai`
+   - EU: `sip:YOUR_PHONE_NUMBER@<credential_id>.sip.eu.vapi.ai`
+   - TLS/SIPS: add port `5061` and `;transport=tls`, for example `sip:YOUR_PHONE_NUMBER@<credential_id>.sip.eu.vapi.ai:5061;transport=tls`
+
+   `YOUR_PHONE_NUMBER` is your chosen SIP number that you will attach to this trunk.
    
    ![Origination Creation](../../static/images/sip/sip-twilio-origination-creation.png)
 

--- a/fern/advanced/sip/sip-zadarma.mdx
+++ b/fern/advanced/sip/sip-zadarma.mdx
@@ -88,7 +88,7 @@ To forward incoming calls from your Zadarma virtual number to Vapi.ai:
 - Click the ⚙ (gear) icon next to your number.
 - Open the **External server** tab.
 - Enable **External server (SIP URI)**.
-- Enter the address: `YOUR_VIRTUAL_NUMBER@sip.vapi.ai` (replace `YOUR_VIRTUAL_NUMBER` with your number in international format).
+- Enter the address for your Vapi region: `YOUR_VIRTUAL_NUMBER@sip.vapi.ai` for US or `YOUR_VIRTUAL_NUMBER@sip.eu.vapi.ai` for EU. Replace `YOUR_VIRTUAL_NUMBER` with your number in international format.
 - Click **Save**.
 
 By following these steps, your Zadarma SIP trunk will be integrated with Vapi.ai, allowing your AI voice assistants to manage calls effectively.

--- a/fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx
+++ b/fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx
@@ -155,23 +155,25 @@ Your SIP provider needs to allow traffic from Vapi's SBC IP addresses. If these 
 
 ### How to check
 
-Ask your SIP provider whether the following IP addresses are on their allowlist:
+Ask your SIP provider whether the Vapi SBC IP addresses for your region are on their allowlist:
 
-- `44.229.228.186/32`
-- `44.238.177.138/32`
+| Region | SIP host | IP addresses |
+| --- | --- | --- |
+| US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32` |
+| EU | `sip.eu.vapi.ai` | `63.182.83.170/32` |
 
 ### How to fix
 
-Ask your SIP provider to add both Vapi SBC IP addresses to their allowlist:
+Ask your SIP provider to add the Vapi SBC IP addresses for your region to their allowlist:
 
-| IP address          | Netmask |
-| ------------------- | ------- |
-| `44.229.228.186`    | `/32`   |
-| `44.238.177.138`    | `/32`   |
+| Region | IP address | Netmask |
+| --- | --- | --- |
+| US | `44.229.228.186` | `/32` |
+| US | `44.238.177.138` | `/32` |
+| EU | `63.182.83.170` | `/32` |
 
 <Warning>
-  Both addresses must be allowed. Vapi may use either one for signaling, so
-  missing one can cause intermittent failures.
+  US organizations must allow both US addresses. Vapi may use either one for signaling, so missing one can cause intermittent failures. EU organizations should allow `63.182.83.170`.
 </Warning>
 
 ## Gateway configuration reference


### PR DESCRIPTION
## Description

Problem: The SIP docs mixed US-only allowlist/TLS guidance with EU SIP setup, so EU customers could configure the wrong host, IP, or port.

This PR updates the SIP networking reference and provider setup guides to describe region-specific SIP signalling, EU TLS on `5061`, and EU static RTP media.

- Updates `fern/advanced/sip/sip-networking.mdx` with EU TLS on port `5061`, EU RTP media on `63.182.83.170`, and the US dynamic-RTP caveat.
- Updates `fern/advanced/sip/sip-trunk.mdx` and `fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx` so allowlist guidance is region-aware.
- Updates Twilio, Plivo, Amazon Chime, Telnyx, and Zadarma SIP setup examples to use the correct regional SIP host and EU IP where applicable.

## Testing Steps

- [x] Run `fern check` -- passes with 0 errors and 5 existing warnings.
- [x] Verify JSON examples are valid -- changed files contain 3 JSON blocks, all valid.
- [x] Verify internal links resolve using slug-aware MDX link validation.
- [x] Run `git diff --check` -- no whitespace errors.
- [x] Cross-check EU SIP evidence: `sip.eu.vapi.ai` resolves to `63.182.83.170`, and TLS on port `5061` succeeds.

