### PR TITLE
remove outdated api only refrence

### DIFF
--- a/fern/customization/speech-configuration.mdx
+++ b/fern/customization/speech-configuration.mdx
@@ -21,8 +21,6 @@ The two main components are:
 
 Fine-tuning these plans helps you adapt the assistant's responsiveness to your use case—whether you want fast, snappy replies or a more patient, human-like conversation flow.
 
-<Note>Currently, these configurations can only be set via API.</Note>
-
 The rest of this page explains each setting and provides practical examples for different scenarios.
 
 ## Start Speaking Plan


### PR DESCRIPTION
## Description

removes a note stating [speaking plans can only be configured via api](https://docs.vapi.ai/customization/speech-configuration) - this is in dashboard under advanced.
<img width="435" height="233" alt="Screenshot 2026-06-11 at 2 38 56 PM" src="https://github.com/user-attachments/assets/0a694222-aecb-4fa3-ad27-8c9f3d86a5b8" />

- 
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
