### PR TITLE
docs: clarify pronunciation dictionaries support Vapi v1 voices only

### DIFF
--- a/fern/assistants/pronunciation-dictionaries.mdx
+++ b/fern/assistants/pronunciation-dictionaries.mdx
@@ -12,7 +12,11 @@ Pronunciation dictionaries are supported by the following voice providers:
 
 - **ElevenLabs** — phoneme rules (IPA and CMU Arpabet) and alias rules
 - **Cartesia** — "sounds-like" aliases and IPA notation (sonic-3 model only)
-- **Vapi built-in voices** — pronunciation dictionaries via a unified locator
+- **Vapi built-in voices** — pronunciation dictionaries via a unified locator (v1 voices only)
+
+<Note>
+  Pronunciation dictionaries are supported on **Vapi v1 voices** only. Vapi **v2** voices are powered by xAI's Grok model, which doesn't support pronunciation dictionaries yet. For v2 voices, use [speech tags](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech#speech-tags) to control pronunciation and delivery inline in your text instead.
+</Note>
 
 ## How Pronunciation Dictionaries Work
 
@@ -88,7 +92,7 @@ Cartesia pronunciation dictionaries use a `text` and `alias` format. Each entry 
 - **IPA notation**: Precise phonetic spelling wrapped in angle brackets (e.g., `"<<ˈ|v|ɑ|ˈ|p|i>>"`)
 
 <Note>
-  Cartesia pronunciation dictionaries are only available with the `sonic-3` model.
+  Cartesia pronunciation dictionaries are only available with the `sonic-3` (or newer) model. In the dashboard, the pronunciation dictionary option only appears once you select a supported model.
 </Note>
 
 ## Implementation
@@ -242,8 +246,8 @@ Cartesia pronunciation dictionaries use a `text` and `alias` format. Each entry 
     {
       "voice": {
         "provider": "vapi",
-        "version": 2,
-        "voiceId": "Elliot",
+        "version": 1,
+        "voiceId": "Kylie",
         "pronunciationDictionary": [
           {
             "pronunciationDictId": "pdict_abc123"


### PR DESCRIPTION
## Description

Problem: The pronunciation dictionaries page never said which Vapi voices support the feature, and its example used `version: 2` (a Grok voice) with a pronunciation dictionary — a config the backend actually rejects.

This clarifies that pronunciation dictionaries work on **Vapi v1 voices only**, points v2 (Grok) users to speech tags instead, and fixes the misleading example.

- Added a note that pronunciation dictionaries are supported on Vapi **v1** voices only. Vapi **v2** voices are powered by xAI's Grok model and don't support them yet — with a link to [xAI speech tags](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech#speech-tags) as the alternative.
- Fixed the Vapi built-in voice example: `version: 2` + `Elliot` → `version: 1` + `Kylie` (a v1 voice that maps to Cartesia `sonic-3`, so it genuinely supports a dictionary).
- Small callout: the Cartesia dictionary option only appears in the dashboard once a `sonic-3` (or newer) model is selected.

File: `fern/assistants/pronunciation-dictionaries.mdx`. No navigation changes.

Related: [PRISM-475](https://linear.app/vapi/issue/PRISM-475/platform-cartesia-pronunciation-dictionary-dashboard-ui-surface) (pronunciation dictionary dashboard work). Companion to the dashboard link fix in VapiAI/vapi#13221.

## Testing Steps

- [x] `fern check` — 0 errors (5 pre-existing config warnings, none on this page)
- [x] JSON example valid (the edited Vapi voice config parses)
- [x] No new internal links (only added link is the external xAI speech-tags URL)
- [x] Example cross-checked against source — voice version mappings in `libs/core/.../voice.types/vapi.types.ts` (Kylie → v1 Cartesia `sonic-3`; v2 = xAI/Grok, no dictionary support)
- [x] Style: active voice, present tense, no marketing language
- [ ] Confirm the v1/v2 note and Cartesia callout render in the preview deployment
