### PR TITLE
fix: correct EU SIP TCP framing and 403/404 FAQ in networking docs

### DIFF
--- a/fern/advanced/sip/sip-networking.mdx
+++ b/fern/advanced/sip/sip-networking.mdx
@@ -24,7 +24,7 @@ The table below summarizes every IP address, port, and protocol you need to allo
 
 | Traffic type | Region | Hostname | IP addresses | Ports | Protocol | Direction |
 | --- | --- | --- | --- | --- | --- | --- |
-| SIP signalling | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5060` | UDP | Bidirectional |
+| SIP signalling | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5060` | UDP/TCP | Bidirectional |
 | SIP signalling | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `5060` | UDP/TCP | Bidirectional |
 | SIP signalling (TLS) | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5061` | TLS | Bidirectional |
 | SIP signalling (TLS) | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `5061` | TLS | Bidirectional |
@@ -48,7 +48,7 @@ These are the public IPs of Vapi's SBC (Session Border Controller) nodes. All SI
 
 | Port | Protocol | Use case |
 | --- | --- | --- |
-| **5060** | UDP/TCP | Default SIP signalling. EU traffic may use TCP on this port. |
+| **5060** | UDP/TCP | Default SIP signalling. UDP and TCP are both supported in US and EU. |
 | **5061** | TLS | SIP over TLS (SIPS) signalling. |
 
 Use port **5060** unless your provider or security requirements mandate encrypted signalling. For TLS/SIPS in either region, use port **5061** with TLS.
@@ -102,7 +102,7 @@ Allow these if your SIP provider or PBX needs to receive traffic from Vapi:
 
 | Rule | Region | Source IP | Destination | Port(s) | Protocol |
 | --- | --- | --- | --- | --- | --- |
-| SIP signalling | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5060` | UDP |
+| SIP signalling | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5060` | UDP/TCP |
 | SIP signalling | EU | `63.182.83.170` | Your SIP server | `5060` | UDP/TCP |
 | SIP signalling (TLS) | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5061` | TLS |
 | SIP signalling (TLS) | EU | `63.182.83.170` | Your SIP server | `5061` | TLS |
@@ -115,7 +115,7 @@ Allow these if your firewall restricts outbound connections:
 
 | Rule | Region | Source | Destination IP | Port(s) | Protocol |
 | --- | --- | --- | --- | --- | --- |
-| SIP signalling | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5060` | UDP |
+| SIP signalling | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5060` | UDP/TCP |
 | SIP signalling | EU | Your SIP server | `63.182.83.170` | `5060` | UDP/TCP |
 | SIP signalling (TLS) | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5061` | TLS |
 | SIP signalling (TLS) | EU | Your SIP server | `63.182.83.170` | `5061` | TLS |
@@ -142,7 +142,7 @@ Allow these if your firewall restricts outbound connections:
     Vapi supports TLS for SIP signalling on port 5061 in both US and EU regions. For encrypted media (SRTP), configure your SIP trunk gateway with the `tls/srtp` outbound protocol option. See the [gateway configuration reference](/advanced/sip/troubleshoot-sip-trunk-credential-errors#gateway-configuration-reference) for details.
   </Accordion>
   <Accordion title="What do SIP 403 and 404 responses mean?">
-    A `403 Forbidden` response with `X-Reason: Invalid credentials` usually means IP allowlisting or authentication failed. A `404 Not Found` response usually means Vapi could not find a matching account or called number for the request.
+    These are standard SIP response codes. A `403 Forbidden` usually means your request was refused, most often because IP allowlisting or authentication failed. A `404 Not Found` usually means the request could not be matched to an account or called number. If you receive a `403`, confirm that your region's signalling IP addresses are allowlisted. If you receive a `404`, confirm the called number is configured in Vapi.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Description

Problem: After #1068 merged, a reviewer pointed out two inaccuracies in the SIP networking docs. The docs implied TCP on port 5060 is EU-only, and the 403/404 FAQ referenced an `X-Reason: Invalid credentials` response header that Vapi does not send.

This PR fixes both so the SIP networking page is accurate.

- Port `5060` now shows UDP/TCP for both US and EU. Both regions accept UDP and TCP, so the previous "EU only" framing could have led US customers to think TCP was unavailable to them.
- The "What do SIP 403 and 404 responses mean?" FAQ no longer mentions the non-existent `X-Reason: Invalid credentials` header. It keeps a plain explanation of what 403 and 404 mean and what to check.

Follow-up to #1068, addressing post-merge review comments from @roshan-vapi.

## Testing Steps

- [x] `fern check` passes (0 errors, 5 pre-existing warnings).
- [x] No internal links or JSON examples changed.
- [x] Confirmed TCP/5060 is region-agnostic and that no `X-Reason` header is emitted, by checking the SIP infrastructure and backend code.
