### PR TITLE
docs: clarify Vapi voice pronunciation dictionaries

### DIFF
--- a/fern/assistants/pronunciation-dictionaries.mdx
+++ b/fern/assistants/pronunciation-dictionaries.mdx
@@ -140,7 +140,13 @@ Cartesia pronunciation dictionaries use a `text` and `alias` format. Each entry 
       "pronunciationDictionaryId": "rjshI10OgN6KxqtJBqO4",
       "versionId": "xJl0ImZzi3cYp61T0UQG",
       "name": "My Custom Dictionary",
-      "rules": [...],
+      "rules": [
+        {
+          "stringToReplace": "UN",
+          "type": "alias",
+          "alias": "United Nations"
+        }
+      ],
       "createdAt": "2024-01-15T10:30:00Z"
     }
     ```
@@ -235,12 +241,14 @@ Cartesia pronunciation dictionaries use a `text` and `alias` format. Each entry 
 ### Vapi Built-in Voices
 
 <Steps>
-  <Step title="Create a Pronunciation Dictionary">
-    Create a pronunciation dictionary using either the ElevenLabs or Cartesia API endpoints shown above. The dictionary ID from either provider can be used with Vapi built-in voices.
+  <Step title="Create an ElevenLabs Pronunciation Dictionary">
+    For Vapi v1 built-in voices, create the pronunciation dictionary through the ElevenLabs endpoint shown above. The response includes both a dictionary ID and a `versionId`; keep both values.
+
+    Vapi built-in voices use a unified `pronunciationDictionary` field, but most v1 built-in voices route through ElevenLabs under the hood. Do not assume a Cartesia dictionary ID works with every Vapi built-in voice. Cartesia dictionary IDs only apply to Vapi voices that are routed to a Cartesia Sonic voice path.
   </Step>
 
   <Step title="Configure Your Assistant's Voice">
-    Add the pronunciation dictionary locator to your Vapi voice configuration.
+    Add the ElevenLabs pronunciation dictionary locator to your Vapi voice configuration.
 
     ```json
     {
@@ -250,7 +258,8 @@ Cartesia pronunciation dictionaries use a `text` and `alias` format. Each entry 
         "voiceId": "Kylie",
         "pronunciationDictionary": [
           {
-            "pronunciationDictId": "pdict_abc123"
+            "pronunciationDictId": "rjshI10OgN6KxqtJBqO4",
+            "versionId": "xJl0ImZzi3cYp61T0UQG"
           }
         ]
       }
@@ -258,7 +267,7 @@ Cartesia pronunciation dictionaries use a `text` and `alias` format. Each entry 
     ```
 
     <Note>
-      The `versionId` field is optional for Vapi voices. It is only required when referencing an ElevenLabs-backed dictionary.
+      For ElevenLabs-backed dictionaries, `versionId` is required. It pins the exact dictionary version that the Vapi voice should use.
     </Note>
   </Step>
 


### PR DESCRIPTION
## Description

Problem: The pronunciation dictionary docs said Vapi built-in voices can use either ElevenLabs or Cartesia dictionary IDs, which is too broad for Vapi v1 voice routing.

This updates the Vapi built-in voice guidance to recommend ElevenLabs dictionary locators with a concrete `versionId`, and clarifies when Cartesia dictionary IDs apply.

- Updated `fern/assistants/pronunciation-dictionaries.mdx` to clarify Vapi v1 built-in voice pronunciation dictionary routing.
- Replaced the generic “either provider” guidance with ElevenLabs-first setup for built-in Vapi v1 voices.
- Added `versionId` to the Vapi voice example so the example matches the runtime locator shape.
- Fixed an invalid JSON placeholder in the ElevenLabs response example.

## Testing Steps

- [x] Run `fern check` -- passes with no errors
- [x] Verify JSON examples are valid (9 JSON blocks parsed successfully)
- [x] Review page content for style guide compliance (active voice, present tense, no marketing language)
- [x] Cross-check API field documentation against the runtime behavior verified during the pronunciation dictionary backfill work

