### PR TITLE
docs: clarify EU SIP API host

### DIFF
--- a/fern/advanced/sip/sip-trunk.mdx
+++ b/fern/advanced/sip/sip-trunk.mdx
@@ -17,6 +17,10 @@ To allow SIP signaling and media between Vapi and your SIP provider, allowlist t
 
 For the complete list of ports, TLS options, RTP ranges, and firewall configuration details, see the [networking and firewall](/advanced/sip/sip-networking) reference.
 
+<Note>
+If your organization is hosted in the EU, create the SIP trunk credential and BYO phone number through `https://api.eu.vapi.ai`, not `https://api.vapi.ai`. Keep the API region and SIP host in the same region: use `api.vapi.ai` with `sip.vapi.ai`, or `api.eu.vapi.ai` with `sip.eu.vapi.ai`.
+</Note>
+
 <Warning>
 We generally don't recommend IP-based authentication for SIP trunks as it can lead to routing issues. Since our servers are shared by many customers, if your telephony provider has multiple customers using IP-based authentication, calls may be routed incorrectly. IP-based authentication works reliably only when your SIP provider offers a unique termination URI or a dedicated SIP server for each customer, as is the case with Plivo and Twilio integrations.
 </Warning>
@@ -40,9 +44,19 @@ Vapi supports multiple SIP trunk configurations, including:
   <Step title="Create a SIP trunk credential in Vapi">
     Use the Vapi API to create a new credential (type: byo-sip-trunk) with your provider's details. This informs Vapi how to connect to your SIP network.
 
+    Set your API base URL for the region where your organization is hosted:
+
+    ```bash
+    # US organizations
+    export VAPI_API_BASE_URL="https://api.vapi.ai"
+
+    # EU organizations
+    export VAPI_API_BASE_URL="https://api.eu.vapi.ai"
+    ```
+
     **Example (using Zadarma):**
     ```bash
-    curl -X POST "https://api.vapi.ai/credential" \
+    curl -X POST "$VAPI_API_BASE_URL/credential" \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer YOUR_VAPI_PRIVATE_KEY" \
       -d '{
@@ -65,9 +79,11 @@ Vapi supports multiple SIP trunk configurations, including:
   <Step title="Associate a phone number with the SIP trunk">
     Link your external phone number (DID) to the SIP trunk credential in Vapi by creating a Phone Number resource.
 
+    Use the same regional API base URL that you used when creating the SIP trunk credential.
+
     **Example:**
     ```bash
-    curl -X POST "https://api.vapi.ai/phone-number" \
+    curl -X POST "$VAPI_API_BASE_URL/phone-number" \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer YOUR_VAPI_PRIVATE_KEY" \
       -d '{
@@ -87,16 +103,18 @@ Vapi supports multiple SIP trunk configurations, including:
         Initiate a call through the Vapi dashboard or API to ensure outbound calls are properly routed.
         
         **API Example:**
-        ```json
-        POST https://api.vapi.ai/call/phone
-        {
-          "assistantId": "YOUR_ASSISTANT_ID",
-          "customer": {
-            "number": "15557654321",
-            "numberE164CheckEnabled": false
-          },
-          "phoneNumberId": "YOUR_PHONE_NUMBER_ID"
-        }
+        ```bash
+        curl -X POST "$VAPI_API_BASE_URL/call/phone" \
+          -H "Content-Type: application/json" \
+          -H "Authorization: Bearer YOUR_VAPI_PRIVATE_KEY" \
+          -d '{
+            "assistantId": "YOUR_ASSISTANT_ID",
+            "customer": {
+              "number": "15557654321",
+              "numberE164CheckEnabled": false
+            },
+            "phoneNumberId": "YOUR_PHONE_NUMBER_ID"
+          }'
         ```
       </Step>
       <Step title="Inbound call test">


### PR DESCRIPTION
## Description

Problem: API users configuring EU SIP trunks could follow the example with `api.vapi.ai` and create resources in the wrong region.

This docs PR clarifies that EU SIP trunk credentials and BYO phone numbers must be created through `https://api.eu.vapi.ai` and keeps the API host paired with the matching SIP host.

- Updates `fern/advanced/sip/sip-trunk.mdx` with a regional API/SIP host note.
- Changes the credential, phone-number, and call examples to use `VAPI_API_BASE_URL`.
- Converts the outbound call example into a real cURL block so the regional base URL is consistent across examples.

## Testing Steps

- [x] Run `fern check` -- passes with 0 errors.
- [x] Verify JSON examples are valid -- changed page now has 0 JSON blocks.
- [x] Verify internal links resolve -- 1 internal link checked.
- [x] Review page content for style guide compliance.
- [x] Cross-check API host guidance against live EU SIP smoke test behavior.
