### PR TITLE
docs(whats-new): add Week of June 15, 2026 entry

### DIFF
--- a/fern/changelog/2026-06-15.mdx
+++ b/fern/changelog/2026-06-15.mdx
@@ -1,0 +1,17 @@
+# What's New: Week of June 15, 2026
+
+1. **Claude Haiku (Global)**: Now available as a model through [Amazon Bedrock](https://docs.vapi.ai/providers/model/anthropic-bedrock) for assistants.
+
+2. **Pronunciation Dictionary Management in Voice Config**: [Pronunciation dictionaries](https://docs.vapi.ai/assistants/pronunciation-dictionaries) configured via the API can now be viewed and managed directly in an assistant's voice settings in the dashboard.
+    - Stale dictionary references are flagged when a voice changes to a model that cannot apply them.
+
+3. **Rotating Tool Messages**: You can now configure multiple [message variants](https://docs.vapi.ai/tools/custom-tools) for a tool, and the assistant picks one at random so longer calls feel less repetitive.
+
+4. **Dynamic Variables in Test Calls**: A dialog lets you set [dynamic variable](https://docs.vapi.ai/assistants/dynamic-variables) values before starting a test call from the dashboard.
+
+5. **Concurrency and Rate Limits in Organization Settings**: Your [call concurrency](https://docs.vapi.ai/calls/call-concurrency) cap and API request rate limit now appear as read-only fields in Organization Settings.
+
+6. **Fixes and Improvements**:
+    - Cartesia voice overrides in squads now apply correctly instead of falling back to a hard-coded default.
+    - Duplicate tools sharing the same `function.name` are de-duplicated during model streaming, preventing duplicate tool calls.
+    - The call concurrency chart in analytics now renders correctly.


### PR DESCRIPTION
## What

Adds the What's New entry for the **Week of June 15, 2026** (`fern/changelog/2026-06-15.mdx`).

This covers what shipped in the weekly release `weekly-20260609 → weekly-20260616-hotfix`. Because last week's release was rolled back and re-shipped this week, this single entry includes both the re-shipped items and the genuinely new ones.

## Entries

1. **Claude Haiku (Global)** — now available as a model through Amazon Bedrock.
2. **Pronunciation Dictionary Management in Voice Config** — view/manage API-configured dictionaries in the dashboard; stale references flagged.
3. **Rotating Tool Messages** — configure multiple tool message variants, picked at random.
4. **Dynamic Variables in Test Calls** — set variable values before starting a dashboard test call.
5. **Concurrency and Rate Limits in Organization Settings** — now shown as read-only fields.
6. **Fixes and Improvements** — squad Cartesia voice overrides, duplicate-tool dedupe at the LLM stream, analytics concurrency chart fix.

## Excluded (per the What's New criteria)

- **Microsoft AI Voice** — gated behind `enable-mai-voices`, restricted to internal `vapi.ai` accounts (not GA).
- **Composer / Simulations** — Alpha features.
- Internal infra (DB cutover, queues/workers, auth migration, CI, typecheck), and very minor UI changes.

## Testing

- Verified rendering on the local Fern build server — formatting, nested sub-bullets (#2, #6), and all five `docs.vapi.ai` links resolve.
- Date confirmed: June 15 is the Monday of the week (filename + title follow the Monday convention).

## Notes

- One link to spot-check on the Fern preview deploy: item 3's **tool message variants → `/tools/custom-tools`** (best-available anchor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)