### PR TITLE
Add dedicated SSO documentation page

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -739,6 +739,8 @@ navigation:
             contents:
               - page: Data flow
                 path: security-and-privacy/data-flow.mdx
+              - page: Single Sign-On (SSO)
+                path: security-and-privacy/sso.mdx
               - page: JWT authentication
                 path: customization/jwt-authentication.mdx
               - page: Recording consent plan

--- a/fern/security-and-privacy/sso.mdx
+++ b/fern/security-and-privacy/sso.mdx
@@ -5,7 +5,7 @@ slug: security-and-privacy/sso
 ---
 
 <Note>
-SSO is an **enterprise-only** feature. It's configured by the Vapi team together with your IT administrator — to get started, email [support@vapi.ai](mailto:support@vapi.ai).
+SSO is an **enterprise-only** feature. To enable it, talk to the [Vapi sales team](/enterprise/plans).
 </Note>
 
 ## Overview
@@ -14,26 +14,14 @@ With SSO, your team signs in to Vapi through your existing identity provider (Id
 
 Vapi works with **any IdP** that supports **SAML 2.0** or **OpenID Connect (OIDC)**. Common providers include **Google Workspace**, **Microsoft Entra ID** (formerly Azure AD), and **Okta**, as well as others like OneLogin, Ping Identity, JumpCloud, and Auth0.
 
-## How setup works
+## Setup
 
-SSO is provisioned as a managed process — the Vapi team works directly with your IT administrator to configure and test the connection:
-
-<Steps>
-  <Step title="Contact support">
-    Email [support@vapi.ai](mailto:support@vapi.ai) to start SSO onboarding.
-  </Step>
-  <Step title="Exchange configuration">
-    Your IT admin and the Vapi team agree on the protocol (SAML or OIDC) and exchange the required connection details — metadata, entity IDs, ACS/redirect URLs, certificates, or client credentials.
-  </Step>
-  <Step title="Test and roll out">
-    Vapi validates sign-in and attribute mapping with your team, then enables SSO for your organization.
-  </Step>
-</Steps>
+Once SSO is enabled for your organization, Vapi provides your IT administrator with a secure link to configure your provider's credentials in the SSO admin panel.
 
 ## Access management
 
-Vapi does **not** support SCIM provisioning. Users gain access the first time they sign in via SSO, and permissions are managed within Vapi using **Role-Based Access Control (RBAC)** at the application layer.
+Vapi does **not** support SCIM provisioning. When a user signs up, they create their own Vapi account; your IT administrator then invites them into your organization. Permissions are managed within Vapi using **Role-Based Access Control (RBAC)** at the application layer.
 
 ## Need help?
 
-To enable SSO or ask about configuration, contact [support@vapi.ai](mailto:support@vapi.ai).
+To enable SSO or ask about configuration, talk to the [Vapi sales team](/enterprise/plans).

--- a/fern/security-and-privacy/sso.mdx
+++ b/fern/security-and-privacy/sso.mdx
@@ -1,0 +1,102 @@
+---
+title: Single Sign-On (SSO)
+subtitle: Connect Vapi to your identity provider with SAML or OIDC for centralized, secure access.
+slug: security-and-privacy/sso
+---
+
+<Note>
+Single Sign-On is an **enterprise-only** feature. SSO is configured by the Vapi support team directly with your IT administrator. To get started, reach out to [support@vapi.ai](mailto:support@vapi.ai).
+</Note>
+
+## Overview
+
+Vapi supports Single Sign-On (SSO) so your team can access the Vapi dashboard using your organization's existing identity provider (IdP). With SSO, users authenticate through your company's login instead of managing a separate set of Vapi credentials, giving your IT team centralized control over who can access your Vapi organization.
+
+Vapi works with **any identity provider** that supports the **SAML 2.0** or **OpenID Connect (OIDC)** standards. Because both are open standards, you are not limited to a specific vendor — if your IdP speaks SAML or OIDC, it can be connected to Vapi.
+
+## Supported protocols
+
+<CardGroup cols={2}>
+  <Card title="SAML 2.0" icon="fa-light fa-key">
+    Security Assertion Markup Language. A widely adopted, XML-based standard for exchanging authentication and authorization data between your IdP and Vapi.
+  </Card>
+  <Card title="OpenID Connect (OIDC)" icon="fa-light fa-id-badge">
+    An authentication layer built on top of OAuth 2.0. A modern, JSON/REST-based standard for verifying user identity.
+  </Card>
+</CardGroup>
+
+## Supported identity providers
+
+Because Vapi supports the SAML and OIDC standards, it integrates with any compliant identity provider. Commonly used providers include:
+
+<CardGroup cols={3}>
+  <Card title="Google Workspace" icon="fa-brands fa-google">
+    Connect via SAML or OIDC using Google as your identity provider.
+  </Card>
+  <Card title="Microsoft Entra ID" icon="fa-brands fa-microsoft">
+    Connect via SAML or OIDC using Microsoft Entra ID (formerly Azure AD).
+  </Card>
+  <Card title="Okta" icon="fa-light fa-circle-check">
+    Connect via SAML or OIDC using Okta as your identity provider.
+  </Card>
+</CardGroup>
+
+Other common providers that work with Vapi include OneLogin, Ping Identity, JumpCloud, Auth0, and Duo. If your provider supports SAML 2.0 or OIDC, it can be connected — even if it is not listed here.
+
+## How setup works
+
+SSO is provisioned as a managed, white-glove process. The Vapi support team works directly with your IT administrator to configure and test the connection end to end.
+
+<Steps>
+  <Step title="Reach out to Vapi support">
+    Contact [support@vapi.ai](mailto:support@vapi.ai) and let us know you'd like to enable SSO. We'll connect you with the team that manages enterprise SSO onboarding.
+  </Step>
+  <Step title="Choose your protocol and provider">
+    Decide whether you'll connect using SAML or OIDC, and identify the identity provider (for example, Google, Microsoft Entra ID, or Okta) your organization uses.
+  </Step>
+  <Step title="Exchange configuration metadata">
+    Your IT administrator and the Vapi team exchange the required connection details — such as metadata URLs, entity IDs, ACS/redirect URLs, certificates, and client credentials — to establish trust between your IdP and Vapi.
+  </Step>
+  <Step title="Test and verify">
+    Together with your IT team, Vapi validates that users can sign in successfully and that attributes are mapped correctly.
+  </Step>
+  <Step title="Roll out to your team">
+    Once verified, SSO is enabled for your organization and your users sign in through your identity provider.
+  </Step>
+</Steps>
+
+## User provisioning and SCIM
+
+Vapi does **not** currently support automated user provisioning via **SCIM**. User accounts are not automatically created, updated, or deactivated based on changes in your identity provider's directory.
+
+Instead, users gain access to your Vapi organization the first time they authenticate through SSO, and access is managed within Vapi using [Role-Based Access Control](#role-based-access-control-rbac).
+
+## Role-Based Access Control (RBAC)
+
+While Vapi does not support directory-level provisioning through SCIM, it does provide **Role-Based Access Control (RBAC)** at the application layer. RBAC lets you control what members of your organization can see and do within Vapi by assigning roles that grant the appropriate level of access.
+
+This gives your team granular control over permissions inside Vapi, independent of your identity provider's group structure.
+
+## FAQs
+
+<AccordionGroup>
+  <Accordion title="Is SSO available on all plans?">
+    No. SSO is an enterprise-only feature. Contact [support@vapi.ai](mailto:support@vapi.ai) to learn more about enterprise plans.
+  </Accordion>
+  <Accordion title="Which identity providers does Vapi support?">
+    Vapi supports any identity provider that implements SAML 2.0 or OIDC, including Google Workspace, Microsoft Entra ID (formerly Azure AD), Okta, and others.
+  </Accordion>
+  <Accordion title="Can I configure SSO myself in the dashboard?">
+    No. SSO is configured by the Vapi support team directly with your IT administrator to ensure the connection is set up and tested correctly.
+  </Accordion>
+  <Accordion title="Does Vapi support SCIM for user provisioning?">
+    No. Vapi does not currently support SCIM. Access within your organization is managed using Role-Based Access Control (RBAC) at the application layer.
+  </Accordion>
+  <Accordion title="How do I get started with SSO?">
+    Reach out to [support@vapi.ai](mailto:support@vapi.ai) and our team will work with your IT administrator to configure SSO for your organization.
+  </Accordion>
+</AccordionGroup>
+
+## Need help?
+
+To enable SSO or ask questions about configuration, contact [support@vapi.ai](mailto:support@vapi.ai). Our team will coordinate with your IT administrator to get your organization set up.

--- a/fern/security-and-privacy/sso.mdx
+++ b/fern/security-and-privacy/sso.mdx
@@ -12,7 +12,7 @@ SSO is an **enterprise-only** feature. To enable it, talk to the [Vapi sales tea
 
 With SSO, your team signs in to Vapi through your existing identity provider (IdP) instead of separate Vapi credentials, giving IT centralized control over access.
 
-Vapi works with **any IdP** that supports **SAML 2.0** or **OpenID Connect (OIDC)**. Common providers include **Google Workspace**, **Microsoft Entra ID** (formerly Azure AD), and **Okta**, as well as others like OneLogin, Ping Identity, JumpCloud, and Auth0.
+Vapi works with **any IdP** that supports **SAML 2.0** or **OpenID Connect (OIDC)**, including **Google Workspace**, **Microsoft Entra ID** (formerly Azure AD), and **Okta**.
 
 ## Setup
 

--- a/fern/security-and-privacy/sso.mdx
+++ b/fern/security-and-privacy/sso.mdx
@@ -1,102 +1,39 @@
 ---
 title: Single Sign-On (SSO)
-subtitle: Connect Vapi to your identity provider with SAML or OIDC for centralized, secure access.
+subtitle: Let your team access Vapi through your identity provider using SAML or OIDC.
 slug: security-and-privacy/sso
 ---
 
 <Note>
-Single Sign-On is an **enterprise-only** feature. SSO is configured by the Vapi support team directly with your IT administrator. To get started, reach out to [support@vapi.ai](mailto:support@vapi.ai).
+SSO is an **enterprise-only** feature. It's configured by the Vapi team together with your IT administrator — to get started, email [support@vapi.ai](mailto:support@vapi.ai).
 </Note>
 
 ## Overview
 
-Vapi supports Single Sign-On (SSO) so your team can access the Vapi dashboard using your organization's existing identity provider (IdP). With SSO, users authenticate through your company's login instead of managing a separate set of Vapi credentials, giving your IT team centralized control over who can access your Vapi organization.
+With SSO, your team signs in to Vapi through your existing identity provider (IdP) instead of separate Vapi credentials, giving IT centralized control over access.
 
-Vapi works with **any identity provider** that supports the **SAML 2.0** or **OpenID Connect (OIDC)** standards. Because both are open standards, you are not limited to a specific vendor — if your IdP speaks SAML or OIDC, it can be connected to Vapi.
-
-## Supported protocols
-
-<CardGroup cols={2}>
-  <Card title="SAML 2.0" icon="fa-light fa-key">
-    Security Assertion Markup Language. A widely adopted, XML-based standard for exchanging authentication and authorization data between your IdP and Vapi.
-  </Card>
-  <Card title="OpenID Connect (OIDC)" icon="fa-light fa-id-badge">
-    An authentication layer built on top of OAuth 2.0. A modern, JSON/REST-based standard for verifying user identity.
-  </Card>
-</CardGroup>
-
-## Supported identity providers
-
-Because Vapi supports the SAML and OIDC standards, it integrates with any compliant identity provider. Commonly used providers include:
-
-<CardGroup cols={3}>
-  <Card title="Google Workspace" icon="fa-brands fa-google">
-    Connect via SAML or OIDC using Google as your identity provider.
-  </Card>
-  <Card title="Microsoft Entra ID" icon="fa-brands fa-microsoft">
-    Connect via SAML or OIDC using Microsoft Entra ID (formerly Azure AD).
-  </Card>
-  <Card title="Okta" icon="fa-light fa-circle-check">
-    Connect via SAML or OIDC using Okta as your identity provider.
-  </Card>
-</CardGroup>
-
-Other common providers that work with Vapi include OneLogin, Ping Identity, JumpCloud, Auth0, and Duo. If your provider supports SAML 2.0 or OIDC, it can be connected — even if it is not listed here.
+Vapi works with **any IdP** that supports **SAML 2.0** or **OpenID Connect (OIDC)**. Common providers include **Google Workspace**, **Microsoft Entra ID** (formerly Azure AD), and **Okta**, as well as others like OneLogin, Ping Identity, JumpCloud, and Auth0.
 
 ## How setup works
 
-SSO is provisioned as a managed, white-glove process. The Vapi support team works directly with your IT administrator to configure and test the connection end to end.
+SSO is provisioned as a managed process — the Vapi team works directly with your IT administrator to configure and test the connection:
 
 <Steps>
-  <Step title="Reach out to Vapi support">
-    Contact [support@vapi.ai](mailto:support@vapi.ai) and let us know you'd like to enable SSO. We'll connect you with the team that manages enterprise SSO onboarding.
+  <Step title="Contact support">
+    Email [support@vapi.ai](mailto:support@vapi.ai) to start SSO onboarding.
   </Step>
-  <Step title="Choose your protocol and provider">
-    Decide whether you'll connect using SAML or OIDC, and identify the identity provider (for example, Google, Microsoft Entra ID, or Okta) your organization uses.
+  <Step title="Exchange configuration">
+    Your IT admin and the Vapi team agree on the protocol (SAML or OIDC) and exchange the required connection details — metadata, entity IDs, ACS/redirect URLs, certificates, or client credentials.
   </Step>
-  <Step title="Exchange configuration metadata">
-    Your IT administrator and the Vapi team exchange the required connection details — such as metadata URLs, entity IDs, ACS/redirect URLs, certificates, and client credentials — to establish trust between your IdP and Vapi.
-  </Step>
-  <Step title="Test and verify">
-    Together with your IT team, Vapi validates that users can sign in successfully and that attributes are mapped correctly.
-  </Step>
-  <Step title="Roll out to your team">
-    Once verified, SSO is enabled for your organization and your users sign in through your identity provider.
+  <Step title="Test and roll out">
+    Vapi validates sign-in and attribute mapping with your team, then enables SSO for your organization.
   </Step>
 </Steps>
 
-## User provisioning and SCIM
+## Access management
 
-Vapi does **not** currently support automated user provisioning via **SCIM**. User accounts are not automatically created, updated, or deactivated based on changes in your identity provider's directory.
-
-Instead, users gain access to your Vapi organization the first time they authenticate through SSO, and access is managed within Vapi using [Role-Based Access Control](#role-based-access-control-rbac).
-
-## Role-Based Access Control (RBAC)
-
-While Vapi does not support directory-level provisioning through SCIM, it does provide **Role-Based Access Control (RBAC)** at the application layer. RBAC lets you control what members of your organization can see and do within Vapi by assigning roles that grant the appropriate level of access.
-
-This gives your team granular control over permissions inside Vapi, independent of your identity provider's group structure.
-
-## FAQs
-
-<AccordionGroup>
-  <Accordion title="Is SSO available on all plans?">
-    No. SSO is an enterprise-only feature. Contact [support@vapi.ai](mailto:support@vapi.ai) to learn more about enterprise plans.
-  </Accordion>
-  <Accordion title="Which identity providers does Vapi support?">
-    Vapi supports any identity provider that implements SAML 2.0 or OIDC, including Google Workspace, Microsoft Entra ID (formerly Azure AD), Okta, and others.
-  </Accordion>
-  <Accordion title="Can I configure SSO myself in the dashboard?">
-    No. SSO is configured by the Vapi support team directly with your IT administrator to ensure the connection is set up and tested correctly.
-  </Accordion>
-  <Accordion title="Does Vapi support SCIM for user provisioning?">
-    No. Vapi does not currently support SCIM. Access within your organization is managed using Role-Based Access Control (RBAC) at the application layer.
-  </Accordion>
-  <Accordion title="How do I get started with SSO?">
-    Reach out to [support@vapi.ai](mailto:support@vapi.ai) and our team will work with your IT administrator to configure SSO for your organization.
-  </Accordion>
-</AccordionGroup>
+Vapi does **not** support SCIM provisioning. Users gain access the first time they sign in via SSO, and permissions are managed within Vapi using **Role-Based Access Control (RBAC)** at the application layer.
 
 ## Need help?
 
-To enable SSO or ask questions about configuration, contact [support@vapi.ai](mailto:support@vapi.ai). Our team will coordinate with your IT administrator to get your organization set up.
+To enable SSO or ask about configuration, contact [support@vapi.ai](mailto:support@vapi.ai).


### PR DESCRIPTION
Add an enterprise SSO page covering SAML and OIDC support with major
identity providers (Google, Microsoft Entra ID, Okta). Documents the
support-managed setup process, the lack of SCIM support, and
application-layer RBAC. Linked from the Security and privacy nav section.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018CQ4CgW3zUqwTiBrZih8V3