### PR TITLE
Add Workflows to Squads migration guide

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -427,6 +427,9 @@ navigation:
       - section: Workflows
         collapsed: open-by-default
         contents:
+          - page: Migrate to Squads
+            path: workflows/legacy-migration.mdx
+            icon: fa-light fa-arrow-right-arrow-left
           - page: Quickstart
             path: workflows/quickstart.mdx
             icon: fa-light fa-rocket

--- a/fern/static/workflow-migration-guide.md
+++ b/fern/static/workflow-migration-guide.md
@@ -1,0 +1,209 @@
+# Vapi Workflows → Squads Migration Guide
+
+A self-contained reference for migrating a Vapi **Workflow** to a **Squad** before Workflows is retired on **August 18, 2026**.
+
+**How to use this file:** Attach it to an AI coding assistant (Claude Code, Composer, Cursor, or any LLM) as context, along with your existing workflow's configuration (the workflow JSON, or a description of its nodes and edges). Ask the assistant to draft the equivalent Squad. The mapping table, steps, and rules below give the model everything it needs to produce a correct, focused Squad without re-reading the docs site.
+
+**Deadline:** Workflows stop running on **August 18, 2026**. From **August 19, 2026** onward, existing workflows will no longer run. Migrate before then to avoid disruption.
+
+**Canonical web version:** https://docs.vapi.ai/workflows/legacy-migration
+
+---
+
+## Table of contents
+
+1. [What's changing](#1-whats-changing)
+2. [Mental model](#2-mental-model)
+3. [Concept mapping (Workflows → Squads)](#3-concept-mapping-workflows--squads)
+4. [Rules an agent should follow](#4-rules-an-agent-should-follow)
+5. [Migration steps](#5-migration-steps)
+6. [Squad configuration reference](#6-squad-configuration-reference)
+7. [Variable extraction](#7-variable-extraction)
+8. [Validation checklist](#8-validation-checklist)
+9. [FAQs](#9-faqs)
+10. [Resources](#10-resources)
+
+---
+
+## 1. What's changing
+
+- Workflows will be retired by **August 18, 2026**. From **August 19, 2026** onward, existing workflows will no longer run.
+- Workflows are no longer recommended for new builds. Use **Assistants** for most cases, or **Squads** for multi-assistant setups.
+- **Squads** is the recommended replacement for Workflows.
+- If you are no longer using Workflows, no action is required.
+
+**Why the change:** current AI systems aren't reliable as fully autonomous graph-walking agents — they struggle to simultaneously hold the current node's instructions and reason about every possible next step and its trigger conditions. The Squads pattern (specialized assistants that hand off to each other) has consistently produced better results.
+
+---
+
+## 2. Mental model
+
+Instead of a visual graph of nodes and edges, a Squad is a set of specialized **assistants** that **hand off** to each other during one continuous conversation. Each assistant owns one focused part of the conversation, with clear handoff conditions in between. Conversation context is preserved across handoffs.
+
+---
+
+## 3. Concept mapping (Workflows → Squads)
+
+| Workflows | Squads |
+| --- | --- |
+| Conversation Node | Squad member (assistant with its own prompt, voice, model, and tools) |
+| Edge condition | Handoff tool with a description of when to transfer |
+| Global Node | Assistant with a broad handoff condition (e.g. "user wants to speak to a human" or "user says hotword") |
+| Extract Variables | Variable extraction in the Handoff tool, passed across the full Squad |
+| API Request Node | Custom or API Request tool attached to a Squad member |
+| Transfer Call Node | Transfer call tool attached to a Squad member |
+| Start Node | First member in the Squad `members` array |
+
+---
+
+## 4. Rules an agent should follow
+
+These are the most important judgment rules — apply them before generating any Squad:
+
+1. **Do NOT do a 1:1 node-to-assistant mapping.** Workflows often have dozens of nodes (e.g. IVR menus). A 1:1 migration creates too many assistants and is hard to maintain.
+2. **Bundle as much as possible into a single assistant.** Squads work best for **linear, unidirectional** flows. Start with one assistant and only split when there is a clear functional boundary.
+3. **Avoid cyclical handoffs.** If two stages would hand off back and forth repeatedly within one conversation, consolidate them into a single assistant. Frequent cyclical handoffs add latency and can introduce hallucinations.
+   - Good fit for separate assistants: a predictable one-directional path like `triage → voicemail → SDR`.
+   - Bad fit (consolidate instead): a pair like `SDR ↔ FAQ` that would bounce back and forth many times in a single call.
+4. **Keep each assistant focused.** One clear responsibility, a short prompt, 1–3 goals maximum. Attach only the tools that stage needs.
+5. **One handoff tool per transition.** Replace each edge with a handoff tool on the source assistant, with a plain-language description of when to hand off.
+6. **The first member is the entry point** (equivalent to the Start Node).
+
+---
+
+## 5. Migration steps
+
+### Step 1 — Map the existing workflow
+
+Document what the workflow does before building anything:
+
+- List each node and its purpose.
+- Note the condition on each edge.
+- Identify every extracted variable and where it's used downstream.
+- Note any API calls or transfers to phone numbers.
+
+### Step 2 — Decide on assistants (consolidate aggressively)
+
+Apply the rules in section 4. Group related nodes into a small number of well-defined **stages** (e.g. `intake → triage → scheduling → human handoff`), then create **one assistant per stage**. Bundle stages that would hand off cyclically into one assistant.
+
+For each assistant: give it a clear responsibility, a focused prompt (1–3 goals), and only the tools it needs (API requests, transfers, etc.).
+
+Stage-based example: https://docs.vapi.ai/squads/examples/clinic-triage-scheduling-handoff-tool
+
+### Step 3 — Add handoff tools (replace edges)
+
+For each transition between stages, add a [Handoff tool](https://docs.vapi.ai/squads/handoff) on the source assistant:
+
+- Set the destination to the next assistant (or a phone number for transfers).
+- Write a clear description of **when** to hand off — this replaces the edge condition.
+- For AI-based conditions (e.g. "user wants to talk about pricing"), describe the condition in plain language.
+- For logical conditions (e.g. `{{ customer_tier == "VIP" }}`), extract the value first (see Step 4), then reference it in the handoff tool description.
+
+### Step 4 — Handle variable extraction
+
+Configure variable extraction in each handoff so key data passes to the next assistant. Variables extracted mid-conversation are available across the full Squad. See section 7 for the important caveats.
+
+### Step 5 — Assemble the Squad
+
+- The first member in the `members` array is the entry point.
+- Use `memberOverrides` to standardize settings across **all** members (e.g. the same voice throughout). To override a **single** member, use `assistantOverrides` on that member.
+
+See section 6 for config.
+
+### Step 6 — Test
+
+Use the built-in calling feature to test all conversation paths before going live. Check:
+
+- Handoff conditions trigger at the right time.
+- Variables pass correctly between assistants.
+- Edge cases: confused users, unexpected inputs, human-escalation paths.
+
+---
+
+## 6. Squad configuration reference
+
+Minimal Squad with a squad-wide voice override (`memberOverrides`):
+
+```json
+{
+  "squad": {
+    "members": [
+      { "assistantId": "your-first-assistant-id" },
+      { "assistantId": "your-second-assistant-id" }
+    ],
+    "memberOverrides": {
+      "voice": {
+        "provider": "vapi",
+        "version": 2,
+        "voiceId": "Elliot"
+      }
+    }
+  }
+}
+```
+
+- `members` — ordered array; index 0 is the entry point (Start Node equivalent). Each member is either `{ "assistantId": "..." }` (saved assistant) or `{ "assistant": { ... } }` (transient, inline assistant).
+- `memberOverrides` — overrides applied to **all** members without modifying the underlying assistants. Use for squad-wide settings like voice.
+- `assistantOverrides` — set **on an individual member** to override just that one assistant.
+
+Using Workflows via API? Replace `workflowId` with `squadId` in your call configuration. Squads API reference: https://docs.vapi.ai/api-reference/squads/create
+
+---
+
+## 7. Variable extraction
+
+Configure variable extraction in each [Handoff tool](https://docs.vapi.ai/squads/handoff#variable-extraction) to pass data to the next assistant.
+
+**How it differs from Workflows:** Squads extract variables with an LLM at handoff time (a schema-driven extraction against the conversation transcript), then pass them to the next assistant. This is **best-effort, not deterministic**:
+
+- If a value isn't clearly present in the conversation, or a transient model error occurs, extraction can return empty — and the handoff still proceeds.
+- Define clear extraction schemas, and **test that business-critical variables are reliably captured** before depending on them downstream.
+- For strictly deterministic values, capture them via a tool or API response rather than relying on transcript extraction.
+
+Control what conversation context carries across a handoff with context engineering: https://docs.vapi.ai/squads/handoff#context-engineering
+
+---
+
+## 8. Validation checklist
+
+Before going live, verify:
+
+- [ ] Each Conversation Node's logic is captured (stages consolidated where appropriate).
+- [ ] Assistants are kept to the minimum needed; no cyclical handoff pairs remain split.
+- [ ] Every handoff condition triggers at the right time.
+- [ ] Variable extraction passes the right data between assistants.
+- [ ] Tools, API requests, and transfers are attached to the correct assistant.
+- [ ] Business-critical variables are reliably extracted (tested, not assumed).
+- [ ] Test calls cover **all** conversation paths, including edge cases.
+- [ ] API integrations send `squadId` instead of `workflowId`.
+
+---
+
+## 9. FAQs
+
+**Why is Workflows being retired?** Squads consistently produces better results for customers. Rather than maintaining two parallel products, Vapi is going all-in on Squads.
+
+**Will my workflows stop working immediately on the deprecation date?** Yes. After August 18, 2026, existing workflows will no longer run. Complete your migration before then.
+
+**Do I need to rebuild everything from scratch?** No — the concepts map closely. Each Conversation Node becomes a Squad member and each edge becomes a Handoff tool. The main work is rewriting prompts to be more focused and configuring handoff tools with clear transfer conditions.
+
+**What if I need deterministic routing?** For strict logical conditions (e.g. `{{ customer_tier == "VIP" }}`), extract the relevant variable first and reference it in the handoff tool description. For edge cases, contact support@vapi.ai.
+
+**What happens to my workflow data?** Historical call data remains accessible in your call logs. Workflows-specific post-call data (nodes traversed, extracted variables from Workflow runs) remains viewable for existing calls.
+
+**I'm using Workflows via API — do I need to change my integration?** Yes. Switch from passing `workflowId` to passing `squadId`. See https://docs.vapi.ai/api-reference/squads/create
+
+**Can I get help migrating?** Contact support@vapi.ai. High-volume users can arrange a walkthrough. Vapi also added a **Composer skill** that auto-drafts a Squad from your existing workflow — open Composer in your dashboard and ask "help me migrate my workflows to squads." It's a best-effort starting point; always review and test before going live.
+
+---
+
+## 10. Resources
+
+- Migration guide (web): https://docs.vapi.ai/workflows/legacy-migration
+- Squads overview: https://docs.vapi.ai/squads
+- Squads quickstart: https://docs.vapi.ai/squads-example
+- Handoff tool: https://docs.vapi.ai/squads/handoff
+- Variable extraction: https://docs.vapi.ai/squads/handoff#variable-extraction
+- Context engineering: https://docs.vapi.ai/squads/handoff#context-engineering
+- Squads API reference: https://docs.vapi.ai/api-reference/squads/create
+- Clinic triage & scheduling example: https://docs.vapi.ai/squads/examples/clinic-triage-scheduling-handoff-tool

--- a/fern/workflows/legacy-migration.mdx
+++ b/fern/workflows/legacy-migration.mdx
@@ -88,12 +88,18 @@ If anything looks off, fix it manually using the steps below.
 
   Do **not** assume a 1:1 mapping between Workflow conversation nodes and Squad members. Some workflows include dozens of nodes (e.g. IVR-style menus where each node asks a question and extracts a variable). In these cases, a 1:1 migration usually creates too many assistants and makes the system harder to maintain.
 
-  Instead:
+  **Start by bundling as much of the workflow as you can into a single assistant.** Squads work best for *linear, unidirectional* flows where the conversation moves forward through a predictable sequence of stages. Only split work into a separate assistant when there's a clear functional boundary and you don't expect the conversation to bounce back and forth between the two. If two stages would repeatedly hand off to each other throughout a call, consolidate them into one assistant — frequent cyclical handoffs add latency and can introduce hallucinations.
+
+  Then:
 
   - Group related nodes into a small number of well-defined stages (e.g. intake → triage → scheduling → human handoff)
   - Create **one assistant per stage** with a clear responsibility and a focused prompt (1–3 goals max)
   - Use **Handoff tools** to move between stages and extract/pass variables at the boundaries
   - Attach tools (API requests, transfers, etc.) to the assistant responsible for that stage
+
+  <Tip>
+  A predictable, one-directional path like triage → voicemail → SDR is a good fit for separate assistants. A pair like SDR ↔ FAQ that would hand back and forth many times within a single conversation is not — consolidate those into one assistant instead.
+  </Tip>
 
   For an example of this "stage-based" approach, see the [Clinic triage & scheduling example](/squads/examples/clinic-triage-scheduling-handoff-tool).
 
@@ -122,7 +128,7 @@ If anything looks off, fix it manually using the steps below.
   Group your assistants into a Squad:
 
   - The first member in the `members` array is the entry point (equivalent to the Start Node)
-  - Use `assistantOverrides` to standardize settings across members if needed (e.g. same voice throughout)
+  - Use `memberOverrides` to standardize settings across *all* members if needed (e.g. the same voice throughout). To override a single member instead, use `assistantOverrides` on that member.
 
   ```json
   {
@@ -130,7 +136,14 @@ If anything looks off, fix it manually using the steps below.
       "members": [
         { "assistantId": "your-first-assistant-id" },
         { "assistantId": "your-second-assistant-id" }
-      ]
+      ],
+      "memberOverrides": {
+        "voice": {
+          "provider": "vapi",
+          "version": 2,
+          "voiceId": "Elliot"
+        }
+      }
     }
   }
   ```

--- a/fern/workflows/legacy-migration.mdx
+++ b/fern/workflows/legacy-migration.mdx
@@ -9,14 +9,6 @@ description: Migrate your Vapi Workflows to Squads before Workflows is retired o
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. Migrate to [Squads](/squads) before then to avoid disruption.
 </Warning>
 
-## Migrate with an AI assistant
-
-Want help doing the migration? Download the agent-friendly `.md` version of this guide and hand it to an AI coding assistant (Claude Code, Composer, Cursor, or any LLM) along with your existing workflow's configuration. It's a single, self-contained file — dense concept mapping, the consolidation rules, step-by-step instructions, and a validation checklist — written so a model can draft the equivalent Squad without re-reading the docs.
-
-<Download src="../static/workflow-migration-guide.md">
-  <Button intent="primary" rightIcon="download">Download migration guide (.md)</Button>
-</Download>
-
 ## What's changing
 
 Workflows will be retired by August 18, 2026. From August 19, 2026 onward, existing workflows will no longer run.
@@ -58,14 +50,20 @@ Here's how Workflows concepts map to Squads:
 | Transfer Call Node | Transfer call tool attached to a Squad member |
 | Start Node | First member in the Squad members array |
 
-## Fastest path: migrate with Composer (assisted)
+## Fastest path: migrate with AI (assisted)
 
-We've added a **Composer skill** that can take an existing workflow and draft the equivalent Squad for you — generating the assistants, handoff tools, and variable extraction automatically.
+You can have an AI assistant draft the equivalent Squad for you. Two options:
 
-**To use it:** open Composer in your dashboard and ask it in plain language — for example, *"help me migrate my workflows to squads."* Composer will kick off the process and draft the equivalent Squad(s) for you.
+**Option 1 — Composer (in your dashboard).** We've added a **Composer skill** that takes an existing workflow and drafts the equivalent Squad — generating the assistants, handoff tools, and variable extraction automatically. Open Composer in your dashboard and ask it in plain language — for example, *"help me migrate my workflows to squads."* Composer will kick off the process and draft the equivalent Squad(s) for you.
+
+**Option 2 — Download this guide and use your own AI assistant.** Download the agent-friendly `.md` version below and hand it to any AI coding assistant (Claude Code, Cursor, or any LLM) along with your existing workflow's configuration. It's a single, self-contained file — dense concept mapping, the consolidation rules, step-by-step instructions, and a validation checklist — written so a model can draft the equivalent Squad without re-reading the docs.
+
+<Download src="../static/workflow-migration-guide.md">
+  <Button intent="primary" rightIcon="download">Download migration guide (.md)</Button>
+</Download>
 
 <Warning>
-**Composer gives you a starting point, not a finished migration.** It automates the tedious setup, but it is **not guaranteed to be correct or complete**. Always review and test the generated Squad before going live.
+**Either option gives you a starting point, not a finished migration.** AI assistance automates the tedious setup, but it is **not guaranteed to be correct or complete**. Always review and test the generated Squad before going live.
 </Warning>
 
 Before you go live, verify:
@@ -78,7 +76,7 @@ Before you go live, verify:
 
 If anything looks off, fix it manually using the steps below.
 
-**Prefer full control? Skip Composer and follow Steps 1–6.**
+**Prefer full control? Skip the assisted path and follow Steps 1–6.**
 
 ## How to migrate
 
@@ -215,7 +213,7 @@ If anything looks off, fix it manually using the steps below.
   <Accordion title="Can I get help migrating?">
     Please reach out to [support@vapi.ai](mailto:support@vapi.ai) and we'll do our best to help you get unblocked. If you're a high-volume user, we can set up time to walk through your specific setup.
 
-    We've also added a **Composer skill** that auto-drafts a Squad from your existing workflow — just ask Composer "help me migrate my workflows to squads" (see *Fastest path: migrate with Composer* above). It's a best-effort starting point, so always review and test the result before going live.
+    We've also added a **Composer skill** that auto-drafts a Squad from your existing workflow — just ask Composer "help me migrate my workflows to squads" (see *Fastest path: migrate with AI* above). It's a best-effort starting point, so always review and test the result before going live.
   </Accordion>
 
   <Accordion title="Who should I contact if I have questions?">

--- a/fern/workflows/legacy-migration.mdx
+++ b/fern/workflows/legacy-migration.mdx
@@ -1,0 +1,203 @@
+---
+title: Workflows migration guide
+subtitle: Learn how to migrate from Workflows to Squads before August 18, 2026.
+slug: workflows/legacy-migration
+description: Migrate your Vapi Workflows to Squads before Workflows is retired on August 18, 2026.
+---
+
+<Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. Migrate to [Squads](/squads) before then to avoid disruption.
+</Warning>
+
+## What's changing
+
+Workflows will be retired by August 18, 2026. From August 19, 2026 onward, existing workflows will no longer run.
+
+We no longer recommend Workflows for new builds — please use **Assistants** or **Squads** depending on complexity. This page is retained to help you migrate.
+
+### Why we've moved away from Workflows
+
+While the Workflows product is fully built, we've found that current AI systems aren't yet capable of acting as truly autonomous agents that can:
+
+1. Maintain awareness of the current node's instructions
+2. Understand all possible next steps and the conditions required to reach them
+
+In contrast, the Squads pattern has consistently led to better results for customers. We're now focusing on improving the ergonomics and developer experience around Squads to make this approach even more effective.
+
+<Note>
+If you are no longer using Workflows, no action is required.
+</Note>
+
+## What this means
+
+- **Existing workflows** will continue to run until the deprecation date (August 18, 2026). Users are discouraged from creating any new workflows.
+- **Afterwards,** any workflows still in use will stop running entirely.
+- **Squads** is the recommended replacement.
+
+## Understanding the migration
+
+The core mental model shift: instead of a visual graph of nodes and edges, Squads uses specialized assistants that hand off to each other. Each assistant handles one focused part of your conversation, with clear handoff conditions in between.
+
+Here's how Workflows concepts map to Squads:
+
+| Workflows | Squads |
+| --- | --- |
+| Conversation Node | Squad member (assistant with its own prompt, voice, model, and tools) |
+| Edge condition | Handoff tool with a description of when to transfer |
+| Global Node | Assistant with a broad handoff condition (e.g. "user wants to speak to a human" or "user says hotword") |
+| Extract Variables | Variable extraction in the Handoff tool, passed across the full Squad |
+| API Request Node | Custom or API Request tool attached to a Squad member |
+| Transfer Call Node | Transfer call tool attached to a Squad member |
+| Start Node | First member in the Squad members array |
+
+## Fastest path: migrate with Composer (assisted)
+
+We've added a **Composer skill** that can take an existing workflow and draft the equivalent Squad for you — generating the assistants, handoff tools, and variable extraction automatically.
+
+**To use it:** open Composer in your dashboard and ask it in plain language — for example, *"help me migrate my workflows to squads."* Composer will kick off the process and draft the equivalent Squad(s) for you.
+
+<Warning>
+**Composer gives you a starting point, not a finished migration.** It automates the tedious setup, but it is **not guaranteed to be correct or complete**. Always review and test the generated Squad before going live.
+</Warning>
+
+Before you go live, verify:
+
+- Each Conversation Node's logic is captured (stages may need consolidating — see Step 2)
+- Every handoff condition triggers at the right time
+- Variable extraction passes the right data between assistants
+- Tools, API requests, and transfers are attached to the correct assistant
+- Test calls cover **all** conversation paths, including edge cases
+
+If anything looks off, fix it manually using the steps below.
+
+**Prefer full control? Skip Composer and follow Steps 1–6.**
+
+## How to migrate
+
+<Steps>
+  ### Step 1 — Map your existing workflow
+
+  Before building anything in Squads, document what your workflow does:
+
+  - List each node and its purpose
+  - Note the conditions on each edge
+  - Identify any variables being extracted and where they're used downstream
+  - Note any API calls or transfers to phone numbers
+
+  ### Step 2 — Create an assistant for each Conversation Node
+
+  Do **not** assume a 1:1 mapping between Workflow conversation nodes and Squad members. Some workflows include dozens of nodes (e.g. IVR-style menus where each node asks a question and extracts a variable). In these cases, a 1:1 migration usually creates too many assistants and makes the system harder to maintain.
+
+  Instead:
+
+  - Group related nodes into a small number of well-defined stages (e.g. intake → triage → scheduling → human handoff)
+  - Create **one assistant per stage** with a clear responsibility and a focused prompt (1–3 goals max)
+  - Use **Handoff tools** to move between stages and extract/pass variables at the boundaries
+  - Attach tools (API requests, transfers, etc.) to the assistant responsible for that stage
+
+  For an example of this "stage-based" approach, see the [Clinic triage & scheduling example](/squads/examples/clinic-triage-scheduling-handoff-tool).
+
+  ### Step 3 — Add Handoff tools
+
+  Replace your edge conditions with [Handoff tools](/squads/handoff). For each transition:
+
+  - Create a Handoff tool on the source assistant
+  - Set the destination to the next assistant (or phone number for transfers)
+  - Write a clear description of when to hand off — this replaces your edge condition
+
+  For AI-based conditions (e.g. "user wants to talk about pricing"), write the condition in plain language in the Handoff tool description.
+
+  For logical conditions (e.g. `{{ customer_tier == "VIP" }}`), use variable extraction to capture the value, then reference it in the Handoff tool description.
+
+  ### Step 4 — Handle variable extraction
+
+  Variables extracted mid-conversation in Workflows are available across the full Squad via the [Handoff tool's variable extraction](/squads/handoff#variable-extraction). Configure variable extraction in each Handoff to pass key data to the next assistant.
+
+  <Note>
+  **How extraction differs from Workflows:** Squads extracts variables with an LLM at handoff time (a schema-driven extraction against the conversation transcript), then passes them to the next assistant. This handles most cases well, but it's **best-effort, not deterministic**. If a value isn't clearly present in the conversation, or a transient model error occurs, extraction can return empty and the handoff still proceeds. Define clear extraction schemas, and **test that business-critical variables are reliably captured** before depending on them downstream. For strictly deterministic values, capture them via a tool or API response rather than relying on transcript extraction.
+  </Note>
+
+  ### Step 5 — Set up your Squad
+
+  Group your assistants into a Squad:
+
+  - The first member in the `members` array is the entry point (equivalent to the Start Node)
+  - Use `assistantOverrides` to standardize settings across members if needed (e.g. same voice throughout)
+
+  ```json
+  {
+    "squad": {
+      "members": [
+        { "assistantId": "your-first-assistant-id" },
+        { "assistantId": "your-second-assistant-id" }
+      ]
+    }
+  }
+  ```
+
+  ### Step 6 — Test
+
+  Use the built-in calling feature to test all conversation paths before going live. Pay particular attention to:
+
+  - Handoff conditions triggering at the right time
+  - Variables passing correctly between assistants
+  - Edge cases (confused users, unexpected inputs, human escalation paths)
+</Steps>
+
+## Useful resources
+
+<CardGroup cols={2}>
+  <Card title="Squads overview" icon="fa-light fa-eye" href="/squads">
+    Learn how multi-assistant conversations work.
+  </Card>
+  <Card title="Squads quickstart" icon="fa-light fa-bolt-lightning" href="/squads-example">
+    Build your first Squad step by step.
+  </Card>
+  <Card title="Handoff tool" icon="fa-light fa-hand-holding-hand" href="/squads/handoff">
+    Configure transitions between assistants.
+  </Card>
+  <Card title="Variable extraction" icon="fa-light fa-arrow-right-arrow-left" href="/squads/handoff#variable-extraction">
+    Pass data between assistants at handoff time.
+  </Card>
+  <Card title="Context engineering" icon="fa-light fa-sliders" href="/squads/handoff#context-engineering">
+    Control what conversation context carries across handoffs.
+  </Card>
+</CardGroup>
+
+## FAQs
+
+<AccordionGroup>
+  <Accordion title="Why is Workflows being retired?">
+    We've found that Squads consistently produces better results for customers. Rather than maintaining two parallel products, we're going all-in on Squads — it's already the recommended approach for complex voice agents.
+  </Accordion>
+
+  <Accordion title="Will my workflows stop working immediately on the deprecation date?">
+    Yes. After August 18, 2026, existing workflows will no longer run. We recommend completing your migration before then to avoid any disruption.
+  </Accordion>
+
+  <Accordion title="Do I need to rebuild everything from scratch?">
+    Not exactly, since the concepts map closely. Each Conversation Node becomes a Squad member, and each edge becomes a Handoff tool. The main work is rewriting your prompts to be more focused and configuring Handoff tools with clear transfer conditions.
+  </Accordion>
+
+  <Accordion title="What if I need deterministic routing that Squads doesn't support?">
+    Squads with well-written Handoff tool descriptions handles most routing scenarios reliably. For cases where you need strict logical conditions (e.g. `{{ customer_tier == "VIP" }}`), extract the relevant variable first and reference it in your Handoff tool description. If you're hitting a specific edge case, reach out to [support@vapi.ai](mailto:support@vapi.ai) and we can help.
+  </Accordion>
+
+  <Accordion title="What happens to my workflow data (call logs, variables extracted, etc.)?">
+    Your historical call data remains accessible in your call logs. Workflows-specific post-call data (nodes traversed, extracted variables from Workflow runs) will remain viewable for existing calls.
+  </Accordion>
+
+  <Accordion title="I'm using Workflows via API — do I need to change my integration?">
+    Yes. If you're passing a `workflowId` in your call configuration, you'll need to switch to passing a `squadId` instead. See the [Squads API reference](/api-reference/squads/create) for details.
+  </Accordion>
+
+  <Accordion title="Can I get help migrating?">
+    Please reach out to [support@vapi.ai](mailto:support@vapi.ai) and we'll do our best to help you get unblocked. If you're a high-volume user, we can set up time to walk through your specific setup.
+
+    We've also added a **Composer skill** that auto-drafts a Squad from your existing workflow — just ask Composer "help me migrate my workflows to squads" (see *Fastest path: migrate with Composer* above). It's a best-effort starting point, so always review and test the result before going live.
+  </Accordion>
+
+  <Accordion title="Who should I contact if I have questions?">
+    Please reach out to [support@vapi.ai](mailto:support@vapi.ai).
+  </Accordion>
+</AccordionGroup>

--- a/fern/workflows/legacy-migration.mdx
+++ b/fern/workflows/legacy-migration.mdx
@@ -9,6 +9,14 @@ description: Migrate your Vapi Workflows to Squads before Workflows is retired o
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. Migrate to [Squads](/squads) before then to avoid disruption.
 </Warning>
 
+## Migrate with an AI assistant
+
+Want help doing the migration? Download the agent-friendly `.md` version of this guide and hand it to an AI coding assistant (Claude Code, Composer, Cursor, or any LLM) along with your existing workflow's configuration. It's a single, self-contained file — dense concept mapping, the consolidation rules, step-by-step instructions, and a validation checklist — written so a model can draft the equivalent Squad without re-reading the docs.
+
+<Download src="../static/workflow-migration-guide.md">
+  <Button intent="primary" rightIcon="download">Download migration guide (.md)</Button>
+</Download>
+
 ## What's changing
 
 Workflows will be retired by August 18, 2026. From August 19, 2026 onward, existing workflows will no longer run.


### PR DESCRIPTION
## Description

- Added comprehensive migration guide (`workflows/legacy-migration.mdx`) for transitioning from Workflows to Squads before the August 18, 2026 deprecation deadline
- Guide includes:
  - Deprecation timeline and rationale for the product shift
  - Concept mapping table showing how Workflows components translate to Squads
  - Assisted migration path using Composer for auto-drafting equivalent Squads
  - Step-by-step manual migration instructions (6 steps from mapping to testing)
  - Variable extraction and handoff tool configuration guidance
  - Comprehensive FAQ addressing common migration questions
  - Links to related Squads documentation and examples
- Updated `docs.yml` navigation to surface the migration guide prominently under Workflows section

## Testing Steps

- [ ] Run `fern docs dev` and verify the migration guide renders correctly
- [ ] Confirm the new page appears in the Workflows navigation section
- [ ] Verify all internal links (to `/squads`, `/squads/handoff`, etc.) resolve properly
- [ ] Check that the warning banner and note callouts display correctly
- [ ] Validate the concept mapping table and code example format

https://claude.ai/code/session_01KfSaT4cFb2DggCYTctrzEq