### PR TITLE
fix: require SDK release PR approval

### DIFF
--- a/.github/workflows/release-csharp-sdk.yml
+++ b/.github/workflows/release-csharp-sdk.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
     inputs:
       makePR:
-        description: Make Pull Request
-        default: false
+        description: "Compatibility input; SDK releases always open pull requests for manual approval"
+        default: true
         type: boolean      
       version:
         description: "The version of the C# SDK that you would like to release"
@@ -17,11 +17,6 @@ on:
         description: "The version of the C# SDK that you would like to release"
         required: true
         type: string
-      makePR:
-        description: Make Pull Request
-        required: true
-        default: false
-        type: boolean
 
 jobs:
   release:
@@ -41,8 +36,4 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          if [ "${{ github.event.inputs.makePR }}" = "true" ]; then
-            fern generate --api api --group csharp-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug
-          else
-            fern generate --api api --group csharp-sdk --version ${{ inputs.version }} --log-level debug
-          fi
+          fern generate --api api --group csharp-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug

--- a/.github/workflows/release-go-sdk.yml
+++ b/.github/workflows/release-go-sdk.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
     inputs:
       makePR:
-        description: Make Pull Request
-        default: false
+        description: "Compatibility input; SDK releases always open pull requests for manual approval"
+        default: true
         type: boolean          
       version:
         description: "The version of the Go SDK that you would like to release (optional - will auto-increment patch version if not provided)"
@@ -17,11 +17,6 @@ on:
         description: "The version of the Go SDK that you would like to release (optional - will auto-increment patch version if not provided)"
         required: false
         type: string
-      makePR:
-        description: Make Pull Request
-        required: true
-        default: false
-        type: boolean
 
 jobs:
   determine-version:
@@ -86,10 +81,5 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
-          if [ "${{ github.event.inputs.makePR }}" = "true" ]; then
-            echo "Generating Go SDK for version ${{ needs.determine-version.outputs.version }} in pull request mode"
-            fern generate --api api --group go-sdk --version ${{ needs.determine-version.outputs.version }} --mode pull-request --log-level debug
-          else
-            echo "Generating Go SDK for version ${{ needs.determine-version.outputs.version }}"
-            fern generate --api api --group go-sdk --version ${{ needs.determine-version.outputs.version }} --log-level debug
-          fi
+          echo "Generating Go SDK for version ${{ needs.determine-version.outputs.version }} in pull request mode"
+          fern generate --api api --group go-sdk --version ${{ needs.determine-version.outputs.version }} --mode pull-request --log-level debug

--- a/.github/workflows/release-java-sdk.yml
+++ b/.github/workflows/release-java-sdk.yml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       makePR:
-        description: Make Pull Request
-        default: false
+        description: "Compatibility input; SDK releases always open pull requests for manual approval"
+        default: true
         type: boolean          
       version:
-        description: "The version of the C# SDK that you would like to release"
+        description: "The version of the Java SDK that you would like to release"
         required: true
         type: string    
   workflow_dispatch:
@@ -17,11 +17,6 @@ on:
         description: "The version of the Java SDK that you would like to release"
         required: true
         type: string
-      makePR:
-        description: Make Pull Request
-        required: true
-        default: false
-        type: boolean
 
 jobs:
   release:
@@ -42,8 +37,4 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: |
-          if [ "${{ github.event.inputs.makePR }}" = "true" ]; then
-            fern generate --api api --group java-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug
-          else
-            fern generate --api api --group java-sdk --version ${{ inputs.version }} --log-level debug
-          fi
+          fern generate --api api --group java-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug

--- a/.github/workflows/release-php-sdk.yml
+++ b/.github/workflows/release-php-sdk.yml
@@ -1,6 +1,12 @@
 name: Release PHP SDK
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: "The version of the PHP SDK that you would like to release"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -22,4 +28,4 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
-          fern generate --group php-sdk --version ${{ inputs.version }} --log-level debug
+          fern generate --group php-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
     inputs:
       makePR:
-        description: Make Pull Request
-        default: false
+        description: "Compatibility input; SDK releases always open pull requests for manual approval"
+        default: true
         type: boolean          
       version:
         description: "The version of the Python SDK that you would like to release (optional - will auto-increment patch version if not provided)"
@@ -17,11 +17,6 @@ on:
         description: "The version of the Python SDK that you would like to release (optional - will auto-increment patch version if not provided)"
         required: false
         type: string
-      makePR:
-        description: Make Pull Request
-        required: true
-        default: false
-        type: boolean
 
 jobs:
   determine-version:
@@ -87,8 +82,4 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
-          if [ "${{ github.event.inputs.makePR }}" = "true" ]; then
-            fern generate --api api --group python-sdk --version ${{ needs.determine-version.outputs.version }} --mode pull-request --log-level debug
-          else
-            fern generate --api api --group python-sdk --version ${{ needs.determine-version.outputs.version }} --log-level debug
-          fi
+          fern generate --api api --group python-sdk --version ${{ needs.determine-version.outputs.version }} --mode pull-request --log-level debug

--- a/.github/workflows/release-ruby-sdk.yml
+++ b/.github/workflows/release-ruby-sdk.yml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       makePR:
-        description: Make Pull Request
-        default: false
+        description: "Compatibility input; SDK releases always open pull requests for manual approval"
+        default: true
         type: boolean          
       version:
-        description: "The version of the C# SDK that you would like to release"
+        description: "The version of the Ruby SDK that you would like to release"
         required: true
         type: string    
   workflow_dispatch:
@@ -17,11 +17,6 @@ on:
         description: "The version of the Ruby SDK that you would like to release"
         required: true
         type: string
-      makePR:
-        description: Make Pull Request
-        required: true
-        default: false
-        type: boolean
 
 jobs:
   release:
@@ -41,8 +36,4 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         run: |
-          if [ "${{ github.event.inputs.makePR }}" = "true" ]; then
-            fern generate --api api --group ruby-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug
-          else
-            fern generate --api api --group ruby-sdk --version ${{ inputs.version }} --log-level debug
-          fi
+          fern generate --api api --group ruby-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug

--- a/.github/workflows/release-swift-sdk.yml
+++ b/.github/workflows/release-swift-sdk.yml
@@ -1,6 +1,12 @@
 name: Release Swift SDK
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: "The version of the Swift SDK that you would like to release"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
@@ -22,4 +28,4 @@ jobs:
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
-          fern generate --group swift-sdk --version ${{ inputs.version }} --log-level debug
+          fern generate --group swift-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug

--- a/.github/workflows/release-ts-sdk.yml
+++ b/.github/workflows/release-ts-sdk.yml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       makePR:
-        description: Make Pull Request
-        default: false
+        description: "Compatibility input; SDK releases always open pull requests for manual approval"
+        default: true
         type: boolean          
       version:
-        description: "The version of the C# SDK that you would like to release"
+        description: "The version of the TypeScript SDK that you would like to release"
         required: true
         type: string    
   workflow_dispatch:
@@ -17,11 +17,6 @@ on:
         description: "The version of the TypeScript SDK that you would like to release"
         required: true
         type: string
-      makePR:
-        description: Make Pull Request
-        required: true
-        default: false
-        type: boolean
 
 jobs:
   release:
@@ -41,8 +36,4 @@ jobs:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [ "${{ github.event.inputs.makePR }}" = "true" ]; then
-            fern generate --api api --group ts-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug
-          else
-            fern generate --api api --group ts-sdk --version ${{ inputs.version }} --log-level debug
-          fi
+          fern generate --api api --group ts-sdk --version ${{ inputs.version }} --mode pull-request --log-level debug

--- a/fern/apis/api/generators.yml
+++ b/fern/apis/api/generators.yml
@@ -22,6 +22,7 @@ groups:
           token: ${PYPI_TOKEN}
         github:
           repository: VapiAI/server-sdk-python
+          mode: pull-request
         config:
           pydantic_config:
             skip_validation: true
@@ -40,6 +41,7 @@ groups:
           token: OIDC
         github:
           repository: VapiAI/server-sdk-typescript
+          mode: pull-request
         config:
           namespaceExport: Vapi
           allowCustomFetcher: true
@@ -59,6 +61,7 @@ groups:
             prefer-undiscriminated-unions-with-literals: true
         github:
           repository: VapiAI/server-sdk-go
+          mode: pull-request
         config:
           union: v1
         smart-casing: false
@@ -69,6 +72,7 @@ groups:
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-ruby
+          mode: pull-request
         output:
           location: rubygems
           package-name: vapi_server_sdk
@@ -83,6 +87,7 @@ groups:
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-csharp
+          mode: pull-request
         output:
           location: nuget
           package-name: Vapi.Net
@@ -103,6 +108,7 @@ groups:
         version: 2.4.0
         github:
           repository: VapiAI/server-sdk-php
+          mode: pull-request
         config:
           namespace: Vapi
           client-class-name: VapiClient
@@ -114,6 +120,7 @@ groups:
         disable-examples: true
         github:
           repository: VapiAI/server-sdk-swift
+          mode: pull-request
         config:
           clientClassName: VapiClient
           moduleName: Vapi


### PR DESCRIPTION
## Summary
- require Fern-managed server SDK generation to use pull-request mode by default
- remove manual workflow-dispatch toggles that allowed accidental direct SDK release generation
- add callable PHP and Swift SDK release workflows so they match the other server SDK release jobs

## Why
Branch protection should make SDK release changes reviewable before they land. The current docs/Fern release path could still generate SDK commits/releases directly, which left package registries out of sync and gave Vapi no human approval point.

## Test Plan
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' fern/apis/api/generators.yml .github/workflows/release-{ts,python,go,ruby,csharp,java,php,swift}-sdk.yml`
- `fern check`

Linear: PRISM-1030
