### PR TITLE
docs: deprecation banners + "don't create" notice across all Workflows pages

### DIFF
--- a/fern/workflows.mdx
+++ b/fern/workflows.mdx
@@ -5,9 +5,9 @@ slug: workflows
 ---
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-We no longer recommend Workflows for new builds. Prefer **Assistants** or **Squads** depending on complexity. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads). This page is retained for legacy reference.
+Prefer **Assistants** or **Squads** depending on complexity. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads).
 </Warning>
 
 Workflows is a new way to build conversational AI. It allows you to break down AI conversations into discrete steps, and then orchestrate those steps in a way that is easy to manage and modify.
@@ -15,7 +15,7 @@ Workflows is a new way to build conversational AI. It allows you to break down A
 ## Creating Your First Workflow
 
 <Warning>
-The steps below are retained for legacy reference only. **Don't create new workflows** — the dashboard still allows it, but new builds should use [Assistants](/assistants/dynamic-variables) or [Squads](/squads) instead.
+The steps below are retained for legacy reference only. You can no longer create new workflows on the dashboard — build with [Assistants](/assistants/dynamic-variables) or [Squads](/squads) instead.
 </Warning>
 
 Begin by creating an assistant on the Assistants page and providing the required information, such as the assistant's name and capabilities. Once your assistant is set up, switch the model provider to Vapi and click "Create Workflow" when prompted. A modal will appear offering you the option to create a new workflow or attach to an existing one. Choose the appropriate option to proceed to the Workflow Builder.

--- a/fern/workflows.mdx
+++ b/fern/workflows.mdx
@@ -2,12 +2,11 @@
 title: Introduction to Workflows
 subtitle: Break down AI conversations into a visual workflow made up of discrete steps ("nodes") and branches between them ("edges").
 slug: workflows
+hidden: true
 ---
 
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
-
-Prefer **Assistants** or **Squads** depending on complexity. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads).
 </Warning>
 
 Workflows is a new way to build conversational AI. It allows you to break down AI conversations into discrete steps, and then orchestrate those steps in a way that is easy to manage and modify.

--- a/fern/workflows.mdx
+++ b/fern/workflows.mdx
@@ -4,13 +4,19 @@ subtitle: Break down AI conversations into a visual workflow made up of discrete
 slug: workflows
 ---
 
-<Success intent="launch">
-  Workflows is now available to all Vapi users in Open Beta on [the dashboard here](https://dashboard.vapi.ai/workflows). Start building more reliable and structured conversational AI today. 
-</Success>
+<Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+
+We no longer recommend Workflows for new builds. Prefer **Assistants** or **Squads** depending on complexity. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads). This page is retained for legacy reference.
+</Warning>
 
 Workflows is a new way to build conversational AI. It allows you to break down AI conversations into discrete steps, and then orchestrate those steps in a way that is easy to manage and modify.
 
 ## Creating Your First Workflow
+
+<Warning>
+The steps below are retained for legacy reference only. **Don't create new workflows** — the dashboard still allows it, but new builds should use [Assistants](/assistants/dynamic-variables) or [Squads](/squads) instead.
+</Warning>
 
 Begin by creating an assistant on the Assistants page and providing the required information, such as the assistant's name and capabilities. Once your assistant is set up, switch the model provider to Vapi and click "Create Workflow" when prompted. A modal will appear offering you the option to create a new workflow or attach to an existing one. Choose the appropriate option to proceed to the Workflow Builder.
 

--- a/fern/workflows/examples/appointment-scheduling.mdx
+++ b/fern/workflows/examples/appointment-scheduling.mdx
@@ -6,6 +6,8 @@ description: Build a voice AI appointment scheduling workflow with calendar inte
 ---
 
 <Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+
 This example uses Workflows. For new builds, use **Assistants** or **Squads**. See the updated guides: [Assistant - Appointment Scheduling](/assistants/examples/appointment-scheduling) or [Squads](/squads).
 </Warning>
 

--- a/fern/workflows/examples/appointment-scheduling.mdx
+++ b/fern/workflows/examples/appointment-scheduling.mdx
@@ -8,7 +8,7 @@ description: Build a voice AI appointment scheduling workflow with calendar inte
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-This example uses Workflows. For new builds, use **Assistants** or **Squads**. See the updated guides: [Assistant - Appointment Scheduling](/assistants/examples/appointment-scheduling) or [Squads](/squads).
+**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Assistant - Appointment Scheduling](/assistants/examples/appointment-scheduling) or [Squads](/squads) instead, and migrate any existing workflow before the retirement date.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/appointment-scheduling.mdx
+++ b/fern/workflows/examples/appointment-scheduling.mdx
@@ -8,7 +8,7 @@ description: Build a voice AI appointment scheduling workflow with calendar inte
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Assistant - Appointment Scheduling](/assistants/examples/appointment-scheduling) or [Squads](/squads) instead, and migrate any existing workflow before the retirement date.
+See the [Assistant - Appointment Scheduling](/assistants/examples/appointment-scheduling) equivalent, or [Squads](/squads).
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/appointment-scheduling.mdx
+++ b/fern/workflows/examples/appointment-scheduling.mdx
@@ -6,7 +6,7 @@ description: Build a voice AI appointment scheduling workflow with calendar inte
 ---
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
 This example uses Workflows. For new builds, use **Assistants** or **Squads**. See the updated guides: [Assistant - Appointment Scheduling](/assistants/examples/appointment-scheduling) or [Squads](/squads).
 </Warning>

--- a/fern/workflows/examples/clinic-triage-scheduling.mdx
+++ b/fern/workflows/examples/clinic-triage-scheduling.mdx
@@ -6,7 +6,7 @@ description: Build a voice AI clinic workflow with medical triage protocols, app
 ---
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
 This example uses Workflows. For new builds, use **Squads** for multi-assistant triage and scheduling. See: [Squad - Clinic Triage & Scheduling](/squads/examples/clinic-triage-scheduling).
 </Warning>

--- a/fern/workflows/examples/clinic-triage-scheduling.mdx
+++ b/fern/workflows/examples/clinic-triage-scheduling.mdx
@@ -8,7 +8,7 @@ description: Build a voice AI clinic workflow with medical triage protocols, app
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-This example uses Workflows. For new builds, use **Squads** for multi-assistant triage and scheduling. See: [Squad - Clinic Triage & Scheduling](/squads/examples/clinic-triage-scheduling).
+**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Squad - Clinic Triage & Scheduling](/squads/examples/clinic-triage-scheduling) instead, and migrate any existing workflow before the retirement date.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/clinic-triage-scheduling.mdx
+++ b/fern/workflows/examples/clinic-triage-scheduling.mdx
@@ -6,6 +6,8 @@ description: Build a voice AI clinic workflow with medical triage protocols, app
 ---
 
 <Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+
 This example uses Workflows. For new builds, use **Squads** for multi-assistant triage and scheduling. See: [Squad - Clinic Triage & Scheduling](/squads/examples/clinic-triage-scheduling).
 </Warning>
 

--- a/fern/workflows/examples/clinic-triage-scheduling.mdx
+++ b/fern/workflows/examples/clinic-triage-scheduling.mdx
@@ -8,7 +8,7 @@ description: Build a voice AI clinic workflow with medical triage protocols, app
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Squad - Clinic Triage & Scheduling](/squads/examples/clinic-triage-scheduling) instead, and migrate any existing workflow before the retirement date.
+See the [Squad - Clinic Triage & Scheduling](/squads/examples/clinic-triage-scheduling) equivalent.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/ecommerce-order-management.mdx
+++ b/fern/workflows/examples/ecommerce-order-management.mdx
@@ -8,7 +8,7 @@ description: Build a voice AI e-commerce workflow with order tracking, return pr
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Squad - E‑commerce Order Management](/squads/examples/ecommerce-order-management) instead, and migrate any existing workflow before the retirement date.
+See the [Squad - E‑commerce Order Management](/squads/examples/ecommerce-order-management) equivalent.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/ecommerce-order-management.mdx
+++ b/fern/workflows/examples/ecommerce-order-management.mdx
@@ -8,7 +8,7 @@ description: Build a voice AI e-commerce workflow with order tracking, return pr
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-This example uses Workflows. For new builds, use **Squads** with specialized assistants for orders, returns, and VIP support. See: [Squad - E‑commerce Order Management](/squads/examples/ecommerce-order-management).
+**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Squad - E‑commerce Order Management](/squads/examples/ecommerce-order-management) instead, and migrate any existing workflow before the retirement date.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/ecommerce-order-management.mdx
+++ b/fern/workflows/examples/ecommerce-order-management.mdx
@@ -6,7 +6,7 @@ description: Build a voice AI e-commerce workflow with order tracking, return pr
 ---
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
 This example uses Workflows. For new builds, use **Squads** with specialized assistants for orders, returns, and VIP support. See: [Squad - E‑commerce Order Management](/squads/examples/ecommerce-order-management).
 </Warning>

--- a/fern/workflows/examples/ecommerce-order-management.mdx
+++ b/fern/workflows/examples/ecommerce-order-management.mdx
@@ -6,6 +6,8 @@ description: Build a voice AI e-commerce workflow with order tracking, return pr
 ---
 
 <Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+
 This example uses Workflows. For new builds, use **Squads** with specialized assistants for orders, returns, and VIP support. See: [Squad - E‑commerce Order Management](/squads/examples/ecommerce-order-management).
 </Warning>
 

--- a/fern/workflows/examples/lead-qualification.mdx
+++ b/fern/workflows/examples/lead-qualification.mdx
@@ -8,7 +8,7 @@ description: Build a voice AI outbound sales workflow with lead qualification, C
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Assistant - Lead Qualification](/assistants/examples/lead-qualification) or [Squads](/squads) instead, and migrate any existing workflow before the retirement date.
+See the [Assistant - Lead Qualification](/assistants/examples/lead-qualification) equivalent, or [Squads](/squads).
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/lead-qualification.mdx
+++ b/fern/workflows/examples/lead-qualification.mdx
@@ -8,7 +8,7 @@ description: Build a voice AI outbound sales workflow with lead qualification, C
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-This example uses Workflows. For new builds, use **Assistants** or **Squads**. See: [Assistant - Lead Qualification](/assistants/examples/lead-qualification) and [Squads](/squads).
+**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Assistant - Lead Qualification](/assistants/examples/lead-qualification) or [Squads](/squads) instead, and migrate any existing workflow before the retirement date.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/lead-qualification.mdx
+++ b/fern/workflows/examples/lead-qualification.mdx
@@ -6,6 +6,8 @@ description: Build a voice AI outbound sales workflow with lead qualification, C
 ---
 
 <Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+
 This example uses Workflows. For new builds, use **Assistants** or **Squads**. See: [Assistant - Lead Qualification](/assistants/examples/lead-qualification) and [Squads](/squads).
 </Warning>
 

--- a/fern/workflows/examples/lead-qualification.mdx
+++ b/fern/workflows/examples/lead-qualification.mdx
@@ -6,7 +6,7 @@ description: Build a voice AI outbound sales workflow with lead qualification, C
 ---
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
 This example uses Workflows. For new builds, use **Assistants** or **Squads**. See: [Assistant - Lead Qualification](/assistants/examples/lead-qualification) and [Squads](/squads).
 </Warning>

--- a/fern/workflows/examples/multilingual-support.mdx
+++ b/fern/workflows/examples/multilingual-support.mdx
@@ -8,7 +8,7 @@ description: Build a multilingual voice AI customer support workflow with langua
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-This example uses Workflows. For new builds, use a **Squad** with language‑specific assistants. See: [Squad - Multilingual Support](/squads/examples/multilingual-support).
+**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Squad - Multilingual Support](/squads/examples/multilingual-support) instead, and migrate any existing workflow before the retirement date.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/multilingual-support.mdx
+++ b/fern/workflows/examples/multilingual-support.mdx
@@ -8,7 +8,7 @@ description: Build a multilingual voice AI customer support workflow with langua
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Squad - Multilingual Support](/squads/examples/multilingual-support) instead, and migrate any existing workflow before the retirement date.
+See the [Squad - Multilingual Support](/squads/examples/multilingual-support) equivalent.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/multilingual-support.mdx
+++ b/fern/workflows/examples/multilingual-support.mdx
@@ -6,6 +6,8 @@ description: Build a multilingual voice AI customer support workflow with langua
 ---
 
 <Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+
 This example uses Workflows. For new builds, use a **Squad** with language‑specific assistants. See: [Squad - Multilingual Support](/squads/examples/multilingual-support).
 </Warning>
 

--- a/fern/workflows/examples/multilingual-support.mdx
+++ b/fern/workflows/examples/multilingual-support.mdx
@@ -6,7 +6,7 @@ description: Build a multilingual voice AI customer support workflow with langua
 ---
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
 This example uses Workflows. For new builds, use a **Squad** with language‑specific assistants. See: [Squad - Multilingual Support](/squads/examples/multilingual-support).
 </Warning>

--- a/fern/workflows/examples/property-management.mdx
+++ b/fern/workflows/examples/property-management.mdx
@@ -10,7 +10,7 @@ description: Build a voice AI property management system with dynamic call routi
 </Frame>
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
 This example uses Workflows. For new builds, use **Squads** with a router assistant and domain specialists. See: [Squad - Property Management Routing](/squads/examples/property-management).
 </Warning>

--- a/fern/workflows/examples/property-management.mdx
+++ b/fern/workflows/examples/property-management.mdx
@@ -12,7 +12,7 @@ description: Build a voice AI property management system with dynamic call routi
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-This example uses Workflows. For new builds, use **Squads** with a router assistant and domain specialists. See: [Squad - Property Management Routing](/squads/examples/property-management).
+**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Squad - Property Management Routing](/squads/examples/property-management) instead, and migrate any existing workflow before the retirement date.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/property-management.mdx
+++ b/fern/workflows/examples/property-management.mdx
@@ -12,7 +12,7 @@ description: Build a voice AI property management system with dynamic call routi
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-**This example is built on Workflows and will stop working after August 18, 2026.** Don't use it for new projects — build with [Squad - Property Management Routing](/squads/examples/property-management) instead, and migrate any existing workflow before the retirement date.
+See the [Squad - Property Management Routing](/squads/examples/property-management) equivalent.
 </Warning>
 
 ## Overview

--- a/fern/workflows/examples/property-management.mdx
+++ b/fern/workflows/examples/property-management.mdx
@@ -10,6 +10,8 @@ description: Build a voice AI property management system with dynamic call routi
 </Frame>
 
 <Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+
 This example uses Workflows. For new builds, use **Squads** with a router assistant and domain specialists. See: [Squad - Property Management Routing](/squads/examples/property-management).
 </Warning>
 

--- a/fern/workflows/legacy-migration.mdx
+++ b/fern/workflows/legacy-migration.mdx
@@ -6,7 +6,7 @@ description: Migrate your Vapi Workflows to Squads before Workflows is retired o
 ---
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. Migrate to [Squads](/squads) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. Migrate existing workflows to **Assistants** or **Squads** before the retirement date to avoid disruption.
 </Warning>
 
 ## What's changing

--- a/fern/workflows/overview.mdx
+++ b/fern/workflows/overview.mdx
@@ -5,17 +5,9 @@ slug: workflows/overview
 ---
 
 <Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+
 We no longer recommend Workflows for new builds. Prefer **Assistants** or **Squads** depending on complexity. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads). This page is retained for legacy reference.
-
-Why We’ve Moved Away from Workflows
-
-While the Workflows product is fully built, we’ve found that current AI systems aren’t yet capable of acting as truly autonomous agents that can:
-
-1. Maintain awareness of the current node’s instructions
-2. Understand all possible next steps and the conditions required to reach them
-
-In contrast, the Squads pattern has consistently led to better results for customers. We’re now focusing on improving the ergonomics and developer experience around Squads to make this approach even more effective.
-
 </Warning>
 
 ## Introduction

--- a/fern/workflows/overview.mdx
+++ b/fern/workflows/overview.mdx
@@ -6,8 +6,6 @@ slug: workflows/overview
 
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
-
-Prefer **Assistants** or **Squads** depending on complexity. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads).
 </Warning>
 
 ## Introduction

--- a/fern/workflows/overview.mdx
+++ b/fern/workflows/overview.mdx
@@ -5,9 +5,9 @@ slug: workflows/overview
 ---
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-We no longer recommend Workflows for new builds. Prefer **Assistants** or **Squads** depending on complexity. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads). This page is retained for legacy reference.
+Prefer **Assistants** or **Squads** depending on complexity. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads).
 </Warning>
 
 ## Introduction

--- a/fern/workflows/quickstart.mdx
+++ b/fern/workflows/quickstart.mdx
@@ -6,6 +6,8 @@ description: Build a simple agent that greets users and gathers basic informatio
 ---
 
 <Warning>
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+
 We no longer recommend Workflows for new builds. Use **Assistants** for most cases or **Squads** for multi-assistant setups. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads). Existing workflow content remains for reference.
 </Warning>
 

--- a/fern/workflows/quickstart.mdx
+++ b/fern/workflows/quickstart.mdx
@@ -6,9 +6,9 @@ description: Build a simple agent that greets users and gathers basic informatio
 ---
 
 <Warning>
-Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. **Don't create new workflows** — even though the dashboard still allows it. [Migrate to Squads](/workflows/legacy-migration) before then to avoid disruption.
+Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
 
-We no longer recommend Workflows for new builds. Use **Assistants** for most cases or **Squads** for multi-assistant setups. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads). Existing workflow content remains for reference.
+Use **Assistants** for most cases or **Squads** for multi-assistant setups. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads).
 </Warning>
 
 ## Overview

--- a/fern/workflows/quickstart.mdx
+++ b/fern/workflows/quickstart.mdx
@@ -7,8 +7,6 @@ description: Build a simple agent that greets users and gathers basic informatio
 
 <Warning>
 Workflows will be retired on **August 18, 2026**. From August 19, 2026 onward, existing workflows will no longer run. You will no longer be able to create new workflows on the dashboard. [Migrate existing workflows](/workflows/legacy-migration) to **Assistants** or **Squads** before the retirement date to avoid disruption.
-
-Use **Assistants** for most cases or **Squads** for multi-assistant setups. See [Assistants](/assistants/dynamic-variables) and [Squads](/squads).
 </Warning>
 
 ## Overview


### PR DESCRIPTION
## What changed

Brings every Workflows documentation page in line with the deprecation. Previously only the migration guide carried the direct, dated retirement notice — the rest had softer "no longer recommended" banners, and the intro page actively encouraged new builds.

- **Dated retirement banner** (retires **August 18, 2026**) added to the overview, quickstart, and all six example pages, placed above each page's existing recommendation/links.
- **Intro page (`fern/workflows.mdx`)**: replaced the green "Start building today" launch banner with the retirement warning, and added a reminder at the top of the "Creating Your First Workflow" walkthrough.
- **Explicit "don't create new workflows"** wording across all banners, calling out that the dashboard still allows it (since the dashboard has not yet been updated to block creation).

## Why

Workflows is being retired on August 18, 2026. Users landing on any Workflows page — especially the create/quickstart/intro flows — should see a consistent, unambiguous message: don't build new workflows, migrate existing ones to Squads.

## Reviewer notes

- Existing page-specific links (to the matching Assistant/Squad examples) were preserved; the dated notice was added above them, not in place of them.
- On the overview page, the long "Why we've moved away from Workflows" text was trimmed from the banner since that explanation already lives in full on the [migration guide](fern/workflows/legacy-migration.mdx). Happy to restore it outside the banner if preferred.
- The intro page (`/workflows`) is configured to redirect to the quickstart, so most visitors may not see it directly — fixed anyway since the content was live and contradicted the deprecation.
- The `legacy-migration.mdx` banner was left as-is (already approved/live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)