### PR TITLE
Add What's New for week of June 29, 2026

### DIFF
--- a/fern/changelog/2026-06-29.mdx
+++ b/fern/changelog/2026-06-29.mdx
@@ -10,9 +10,7 @@
 
 4. **MCP Child Tools in Dashboard**: When you connect an [MCP server](https://docs.vapi.ai/tools/mcp), the dashboard tool form now lists all child tools it discovers, so you can see exactly what capabilities your MCP server exposes.
 
-5. **New Defaults for API-Created Assistants**: Assistants created via API now default to Elliot v2 voice, gpt-4.1 model, and 0.5 temperature — matching what the dashboard already uses.
-
-6. **Fixes and Improvements**:
+5. **Fixes and Improvements**:
     - Inworld TTS now correctly speaks the first message.
     - ElevenLabs credential endpoints now persist correctly for EU-residency orgs.
     - Fixed assistants page showing an empty state despite existing assistants.

--- a/fern/changelog/2026-06-29.mdx
+++ b/fern/changelog/2026-06-29.mdx
@@ -1,0 +1,20 @@
+# What's New: Week of June 29, 2026
+
+1. **OpenAI Realtime v2**: OpenAI's latest [Realtime v2](https://docs.vapi.ai/providers/model/openai) model is now available for assistants.
+
+2. **AI-Generated Tool Failure and Completion Messages**: You can now set `role: 'system'` on request-failed [tool messages](https://docs.vapi.ai/tools/custom-tools), and the dashboard has a new UI for configuring AI-generated messages when tools fail or complete. This gives assistants more natural responses when tools hit errors.
+
+3. **Call Logs Improvements**:
+    - In squad or handoff calls, transcript messages now show which assistant said what, making it easier to trace conversation flow.
+    - The call detail flyout now shows which assistant or squad handled the call, includes a link to the assistant or squad, and indicates which phone number was used.
+
+4. **MCP Child Tools in Dashboard**: When you connect an [MCP server](https://docs.vapi.ai/tools/mcp), the dashboard tool form now lists all child tools it discovers, so you can see exactly what capabilities your MCP server exposes.
+
+5. **New Defaults for API-Created Assistants**: Assistants created via API now default to Elliot v2 voice, gpt-4.1 model, and 0.5 temperature — matching what the dashboard already uses.
+
+6. **Fixes and Improvements**:
+    - Inworld TTS now correctly speaks the first message.
+    - ElevenLabs credential endpoints now persist correctly for EU-residency orgs.
+    - Fixed assistants page showing an empty state despite existing assistants.
+    - Fixed org switcher keeping the previous assistant ID in the URL.
+    - Fixed call logs dynamic date presets.

--- a/fern/changelog/2026-06-29.mdx
+++ b/fern/changelog/2026-06-29.mdx
@@ -9,10 +9,3 @@
     - The call detail flyout now shows which assistant or squad handled the call, includes a link to the assistant or squad, and indicates which phone number was used.
 
 4. **MCP Child Tools in Dashboard**: When you connect an [MCP server](https://docs.vapi.ai/tools/mcp), the dashboard tool form now lists all child tools it discovers, so you can see exactly what capabilities your MCP server exposes.
-
-5. **Fixes and Improvements**:
-    - Inworld TTS now correctly speaks the first message.
-    - ElevenLabs credential endpoints now persist correctly for EU-residency orgs.
-    - Fixed assistants page showing an empty state despite existing assistants.
-    - Fixed org switcher keeping the previous assistant ID in the URL.
-    - Fixed call logs dynamic date presets.


### PR DESCRIPTION
## Summary
- Adds the weekly What's New changelog entry for the week of June 29, 2026
- Covers: OpenAI Realtime v2, AI-generated tool messages, call log improvements, MCP child tools in dashboard, new API defaults, and bug fixes

## Test plan
- [ ] Verify the page renders correctly at docs.vapi.ai/whats-new
- [ ] Confirm doc links resolve (OpenAI provider, custom tools, MCP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)