### PR TITLE
Add What's New for week of June 29, 2026

### DIFF
--- a/fern/changelog/2026-06-29.mdx
+++ b/fern/changelog/2026-06-29.mdx
@@ -1,0 +1,11 @@
+# What's New: Week of June 29, 2026
+
+1. **OpenAI Realtime v2**: OpenAI's latest [Realtime v2](https://docs.vapi.ai/openai-realtime) model is now available for assistants.
+
+2. **AI-Generated Tool Failure and Completion Messages**: You can now set `role: 'system'` on request-failed [tool messages](https://docs.vapi.ai/tools/custom-tools), and the dashboard has a new UI for configuring AI-generated messages when tools fail or complete. This gives assistants more natural responses when tools hit errors.
+
+3. **Call Logs Improvements**:
+    - The call detail flyout now shows which assistant or squad handled the call, includes a link to the assistant or squad, and indicates which phone number was used.
+    - In squad or handoff calls, transcript messages now show which assistant said what, making it easier to trace conversation flow.
+
+4. **MCP Child Tools in Dashboard**: When you connect an [MCP server](https://docs.vapi.ai/sdk/mcp-server), the dashboard tool form now lists all child tools it discovers, so you can see exactly what capabilities your MCP server exposes.


### PR DESCRIPTION
## Summary
- Re-adds the What's New entry for the June 29 weekly release (reverted in #1091 because the release hadn't shipped yet)
- Updated links: Realtime v2 → `/openai-realtime`, MCP server → `/sdk/mcp-server`
- Reordered Call Logs bullets

## Merge when the weekly release ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)