### PR TITLE
docs: clarify Twilio inbound SIP gateways

### DIFF
--- a/fern/advanced/sip/sip-twilio.mdx
+++ b/fern/advanced/sip/sip-twilio.mdx
@@ -66,7 +66,12 @@ This guide walks you through setting up both outbound and inbound SIP trunking b
 
 2. **Create a SIP Trunk Credential**
    
-   Use the following API call to create a SIP trunk credential, replacing the gateway IP with your Twilio Termination SIP URI:
+   Use the following API call to create a SIP trunk credential. Configure the
+   Twilio termination hostname as an outbound-only gateway. Configure Twilio's
+   published signaling networks as separate inbound-only gateways.
+
+   The example below uses a Dublin termination hostname with Twilio's Ireland
+   and Frankfurt signaling networks:
 
    ```bash
    curl -X POST https://api.vapi.ai/credential \
@@ -77,13 +82,48 @@ This guide walks you through setting up both outbound and inbound SIP trunking b
      "name": "Twilio Trunk",
      "gateways": [
        {
-         "ip": "YOUR_TWILIO_GATEWAY_ID",
-         "inboundEnabled": false
+         "ip": "YOUR_TRUNK_NAME.pstn.dublin.twilio.com",
+         "port": 5060,
+         "inboundEnabled": false,
+         "outboundEnabled": true
+       },
+       {
+         "ip": "54.171.127.192",
+         "netmask": 30,
+         "port": 5060,
+         "inboundEnabled": true,
+         "outboundEnabled": false
+       },
+       {
+         "ip": "35.156.191.128",
+         "netmask": 30,
+         "port": 5060,
+         "inboundEnabled": true,
+         "outboundEnabled": false
        }
      ],
      "outboundLeadingPlusEnabled": true
    }'
    ```
+
+   <Warning>
+     Replace the example hostname and networks with the values for your Twilio
+     trunk's selected edges. Add every primary and failover signaling network
+     that can originate calls. Use Twilio's current [Elastic SIP Trunking IP
+     address list](https://www.twilio.com/docs/sip-trunking/ip-addresses) as the
+     source of truth.
+   </Warning>
+
+   A termination hostname can be used for outbound routing because Vapi
+   resolves it when placing a call. It cannot identify inbound traffic: Vapi
+   must match the source of an incoming SIP request against a numeric IPv4
+   network. The `netmask` value represents the CIDR prefix, so a `/30` network
+   is configured as `"netmask": 30`.
+
+   If you are adding inbound gateways to an existing credential, send a
+   `PATCH /credential/YOUR_CREDENTIAL_ID` request with the complete `gateways`
+   array, including the existing outbound gateway and the new inbound
+   networks.
    
    Note the `id` (credentialId) from the response for the next step.
 
@@ -158,3 +198,10 @@ This guide walks you through setting up both outbound and inbound SIP trunking b
    - In the assistant settings, link it to the phone number you created
    
    Now when someone calls your Twilio number, the call will be routed to your Vapi assistant.
+
+<Note>
+  If inbound calls do not reach Vapi, verify that the credential includes the
+  numeric Twilio signaling networks for every origination edge you configured.
+  Adding only the Twilio termination hostname enables outbound routing but does
+  not allowlist inbound SIP traffic.
+</Note>

--- a/fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx
+++ b/fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx
@@ -50,12 +50,17 @@ Look at your gateway configuration. If `inboundEnabled` is `true` (or omitted, s
 
 You have two options depending on whether you need inbound calling:
 
-**If you need inbound calling**, resolve the hostname to its IPv4 address:
+**If you need inbound calling**, use the source signaling networks published by
+your SIP provider. Providers can use different addresses for outbound routing
+and inbound signaling, so do not assume that resolving an outbound hostname
+returns the addresses that will originate inbound calls.
 
 <Steps>
-<Step title="Look up the IP address">
+<Step title="Find the provider's signaling networks">
 
-Run one of the following commands to resolve your SIP provider's hostname to an IPv4 address:
+Check your provider's SIP trunking documentation for its inbound signaling IP
+addresses or CIDR ranges. If your provider explicitly documents a stable
+hostname as the source of inbound traffic, you can resolve it with:
 
 ```bash title="Terminal"
 dig +short sip.example.com A
@@ -65,13 +70,15 @@ dig +short sip.example.com A
 nslookup sip.example.com
 ```
 
-This returns one or more IPv4 addresses, for example `203.0.113.10`.
+This returns one or more IPv4 addresses, for example `203.0.113.10`. Include
+all primary and failover networks that can originate calls.
 
 </Step>
 
 <Step title="Use the resolved IP in your API request">
 
-Replace the hostname with the numeric IPv4 address in your gateway configuration:
+Represent each provider network as a numeric IPv4 network address and, for a
+CIDR range, set `netmask` to its prefix length:
 
 ```json title="Gateway configuration"
 {
@@ -79,9 +86,10 @@ Replace the hostname with the numeric IPv4 address in your gateway configuration
   "name": "my sip trunk",
   "gateways": [
     {
-      "ip": "203.0.113.10",
+      "ip": "203.0.113.8",
+      "netmask": 30,
       "port": 5060,
-      "outboundEnabled": true,
+      "outboundEnabled": false,
       "inboundEnabled": true
     }
   ]
@@ -92,8 +100,9 @@ Replace the hostname with the numeric IPv4 address in your gateway configuration
 </Steps>
 
 <Note>
-  If your provider's IP address changes, you need to update the gateway
-  configuration with the new address.
+  In this example, `203.0.113.8/30` is written as `"ip": "203.0.113.8"` and
+  `"netmask": 30`. If your provider changes its signaling networks, update the
+  gateway configuration to match.
 </Note>
 
 **If you only need outbound calling**, you can keep the hostname and disable inbound:


### PR DESCRIPTION
## Description

Problem: A Twilio trunk can work for outbound calls while inbound calls are silently blocked if the Vapi credential contains only the Twilio termination hostname.

This explains the split in simple terms: the termination hostname is for outbound routing, while inbound trust uses Twilio's published numeric signaling networks.

- Updates `fern/advanced/sip/sip-twilio.mdx` with a concrete Dublin/Frankfurt example, directional gateway flags, `/30` netmask syntax, and a link to Twilio's live IP list.
- Explains that existing credentials must be PATCHed with the complete gateway array, including both the outbound hostname and inbound networks.
- Corrects `fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx` so customers use provider-published source networks instead of assuming an outbound hostname resolves to the inbound source addresses.
- No navigation changes.

Related: PRISM-1200 and VapiAI/vapi#14042. The product fix and this docs fix are separate PRs, so this PR does not auto-close the shared ticket.

## Testing Steps

- [x] Run `fern check` -- passes with 0 errors. The 5 warnings are existing spec, authentication, and theme warnings.
- [x] Verify all 3 JSON blocks and both cURL JSON payloads are valid.
- [x] Verify internal links resolve to existing pages.
- [x] Review page content for active voice, plain language, and no customer-specific identifiers.
- [x] Cross-check the Ireland `54.171.127.192/30` and Frankfurt `35.156.191.128/30` networks against Twilio's current Elastic SIP Trunking IP address page.
- [x] Cross-check `gateways`, `netmask`, `inboundEnabled`, and `outboundEnabled` against the Vapi credential schema and source fix.
