### PR TITLE
Added xAI to HIPAA

### DIFF
--- a/fern/security-and-privacy/hipaa.mdx
+++ b/fern/security-and-privacy/hipaa.mdx
@@ -67,6 +67,7 @@ When enabling HIPAA compliance, only HIPAA compliant providers may be chosen.
 - **Custom LLM**
 - **Baseten**
 - **Together AI**
+- **xAI**
 
 ### Voice Providers (TTS)
 
@@ -76,12 +77,14 @@ When enabling HIPAA compliance, only HIPAA compliant providers may be chosen.
 - **Rime AI**
 - **Deepgram**
 - **Azure**
+- **xAI**
 
 ### Transcription Providers (STT)
 
 - **Azure**
 - **Deepgram**
 - **Soniox**
+- **xAI**
 
 # FAQs
 


### PR DESCRIPTION
## Description

- Added xAI to the HIPAA Model Providers, Voice Providers, and Transcription Providers list.
  
## Testing Steps

- [ X] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ X] Ensure that the changed pages and code snippets work
