### PR TITLE
Add missing third SIP trunk IP to US allowlist docs

### DIFF
--- a/fern/advanced/sip/sip-chime.mdx
+++ b/fern/advanced/sip/sip-chime.mdx
@@ -52,7 +52,7 @@ Add Vapi's static IP addresses for your Vapi region to the allowed host list:
 
 | Region | IP addresses |
 | --- | --- |
-| US | `44.229.228.186/32`, `44.238.177.138/32` |
+| US | `44.229.228.186/32`, `44.238.177.138/32`, `34.213.129.25/32` |
 | EU | `63.182.83.170/32` |
 
 </Step>

--- a/fern/advanced/sip/sip-networking.mdx
+++ b/fern/advanced/sip/sip-networking.mdx
@@ -24,9 +24,9 @@ The table below summarizes every IP address, port, and protocol you need to allo
 
 | Traffic type | Region | Hostname | IP addresses | Ports | Protocol | Direction |
 | --- | --- | --- | --- | --- | --- | --- |
-| SIP signalling | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5060` | UDP/TCP | Bidirectional |
+| SIP signalling | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138`, `34.213.129.25` | `5060` | UDP/TCP | Bidirectional |
 | SIP signalling | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `5060` | UDP/TCP | Bidirectional |
-| SIP signalling (TLS) | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` | `5061` | TLS | Bidirectional |
+| SIP signalling (TLS) | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138`, `34.213.129.25` | `5061` | TLS | Bidirectional |
 | SIP signalling (TLS) | EU | `sip.eu.vapi.ai` | `63.182.83.170` | `5061` | TLS | Bidirectional |
 | RTP media | US | N/A | No static IPs (dynamic) | `40000`-`60000` | UDP | Bidirectional |
 | RTP media | EU | N/A | `63.182.83.170` | `40000`-`60000` | UDP | Bidirectional |
@@ -39,7 +39,7 @@ Vapi's SIP infrastructure uses static IP addresses for signalling traffic in eac
 
 | Region | Hostname | IP addresses |
 | --- | --- | --- |
-| US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32` |
+| US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32`, `34.213.129.25/32` |
 | EU | `sip.eu.vapi.ai` | `63.182.83.170/32` |
 
 These are the public IPs of Vapi's SBC (Session Border Controller) nodes. All SIP `INVITE`, `REGISTER`, `BYE`, and other signalling messages originate from and are received at the addresses for your region.
@@ -102,9 +102,9 @@ Allow these if your SIP provider or PBX needs to receive traffic from Vapi:
 
 | Rule | Region | Source IP | Destination | Port(s) | Protocol |
 | --- | --- | --- | --- | --- | --- |
-| SIP signalling | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5060` | UDP/TCP |
+| SIP signalling | US | `44.229.228.186`, `44.238.177.138`, `34.213.129.25` | Your SIP server | `5060` | UDP/TCP |
 | SIP signalling | EU | `63.182.83.170` | Your SIP server | `5060` | UDP/TCP |
-| SIP signalling (TLS) | US | `44.229.228.186`, `44.238.177.138` | Your SIP server | `5061` | TLS |
+| SIP signalling (TLS) | US | `44.229.228.186`, `44.238.177.138`, `34.213.129.25` | Your SIP server | `5061` | TLS |
 | SIP signalling (TLS) | EU | `63.182.83.170` | Your SIP server | `5061` | TLS |
 | RTP media | US | Any (dynamic) | Your media server | `40000`-`60000` | UDP |
 | RTP media | EU | `63.182.83.170` | Your media server | `40000`-`60000` | UDP |
@@ -115,9 +115,9 @@ Allow these if your firewall restricts outbound connections:
 
 | Rule | Region | Source | Destination IP | Port(s) | Protocol |
 | --- | --- | --- | --- | --- | --- |
-| SIP signalling | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5060` | UDP/TCP |
+| SIP signalling | US | Your SIP server | `44.229.228.186`, `44.238.177.138`, `34.213.129.25` | `5060` | UDP/TCP |
 | SIP signalling | EU | Your SIP server | `63.182.83.170` | `5060` | UDP/TCP |
-| SIP signalling (TLS) | US | Your SIP server | `44.229.228.186`, `44.238.177.138` | `5061` | TLS |
+| SIP signalling (TLS) | US | Your SIP server | `44.229.228.186`, `44.238.177.138`, `34.213.129.25` | `5061` | TLS |
 | SIP signalling (TLS) | EU | Your SIP server | `63.182.83.170` | `5061` | TLS |
 | RTP media | US | Your media server | Any (dynamic) | `40000`-`60000` | UDP |
 | RTP media | EU | Your media server | `63.182.83.170` | `40000`-`60000` | UDP |

--- a/fern/advanced/sip/sip-plivo.mdx
+++ b/fern/advanced/sip/sip-plivo.mdx
@@ -43,7 +43,7 @@ Indian phone numbers cannot be used with Plivo on Vapi due to TRAI regulations. 
 
         | Region | IP addresses |
         | --- | --- |
-        | US | `44.229.228.186/32`, `44.238.177.138/32` |
+        | US | `44.229.228.186/32`, `44.238.177.138/32`, `34.213.129.25/32` |
         | EU | `63.182.83.170/32` |
         3. **Click** **Create ACL** to save.
         

--- a/fern/advanced/sip/sip-trunk.mdx
+++ b/fern/advanced/sip/sip-trunk.mdx
@@ -12,7 +12,7 @@ To allow SIP signaling and media between Vapi and your SIP provider, allowlist t
 
 | Region | SIP host | Signalling IP addresses | RTP media behavior |
 | --- | --- | --- | --- |
-| US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32` | Dynamic media IPs; allow UDP ports `40000`-`60000` |
+| US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32`, `34.213.129.25/32` | Dynamic media IPs; allow UDP ports `40000`-`60000` |
 | EU | `sip.eu.vapi.ai` | `63.182.83.170/32` | Static media IP `63.182.83.170`; allow UDP ports `40000`-`60000` |
 
 For the complete list of ports, TLS options, RTP ranges, and firewall configuration details, see the [networking and firewall](/advanced/sip/sip-networking) reference.

--- a/fern/advanced/sip/sip-twilio.mdx
+++ b/fern/advanced/sip/sip-twilio.mdx
@@ -43,7 +43,7 @@ This guide walks you through setting up both outbound and inbound SIP trunking b
 
    | Region | SIP host | IP addresses |
    | --- | --- | --- |
-   | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138` |
+   | US | `sip.vapi.ai` | `44.229.228.186`, `44.238.177.138`, `34.213.129.25` |
    | EU | `sip.eu.vapi.ai` | `63.182.83.170` |
    
    Ensure you whitelist the entire IP range as shown below:

--- a/fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx
+++ b/fern/advanced/sip/troubleshoot-sip-trunk-credential-errors.mdx
@@ -168,7 +168,7 @@ Ask your SIP provider whether the Vapi SBC IP addresses for your region are on t
 
 | Region | SIP host | IP addresses |
 | --- | --- | --- |
-| US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32` |
+| US | `sip.vapi.ai` | `44.229.228.186/32`, `44.238.177.138/32`, `34.213.129.25/32` |
 | EU | `sip.eu.vapi.ai` | `63.182.83.170/32` |
 
 ### How to fix
@@ -179,10 +179,11 @@ Ask your SIP provider to add the Vapi SBC IP addresses for your region to their 
 | --- | --- | --- |
 | US | `44.229.228.186` | `/32` |
 | US | `44.238.177.138` | `/32` |
+| US | `34.213.129.25` | `/32` |
 | EU | `63.182.83.170` | `/32` |
 
 <Warning>
-  US organizations must allow both US addresses. Vapi may use either one for signaling, so missing one can cause intermittent failures. EU organizations should allow `63.182.83.170`.
+  US organizations must allow all three US addresses. Vapi may use any of them for signaling, so missing one can cause intermittent failures. EU organizations should allow `63.182.83.170`.
 </Warning>
 
 ## Gateway configuration reference


### PR DESCRIPTION
## Summary
- US SIP signaling can originate from 34.213.129.25 in addition to 44.229.228.186 and 44.238.177.138, but docs only listed two, causing intermittent allowlist failures for customers.
- Added the third IP across all affected pages: sip-trunk, sip-networking, troubleshoot-sip-trunk-credential-errors, sip-twilio, sip-plivo, sip-chime.

## Test plan
- [ ] Confirm 34.213.129.25 is a valid/current Vapi US SBC signaling IP before merge