### PR TITLE
Replace roadmap.vapi.ai/feature-requests links with docs.vapi.ai/whats-new

### DIFF
--- a/fern/support.mdx
+++ b/fern/support.mdx
@@ -40,7 +40,7 @@ We welcome feature requests and feedback from our users to help improve Vapi. Yo
   <Card 
     title="Submit Feature Requests" 
     icon="lightbulb"
-    href="https://roadmap.vapi.ai/feature-requests"
+    href="https://docs.vapi.ai/whats-new"
   >
     Submit and vote on feature requests on our public roadmap board to help shape the future of Vapi.
   </Card>
@@ -48,7 +48,7 @@ We welcome feature requests and feedback from our users to help improve Vapi. Yo
   <Card 
     title="Submit Bug Report" 
     icon="bug"
-    href="https://roadmap.vapi.ai/feature-requests"
+    href="https://docs.vapi.ai/whats-new"
   >
     Report any bugs or issues you encounter while using Vapi to help us improve the platform.
   </Card>

--- a/fern/workflows.mdx
+++ b/fern/workflows.mdx
@@ -48,7 +48,7 @@ Begin by creating an assistant on the Assistants page and providing the required
 - **Creating Conditionals:** To create conditionals, first add a condition node. Then, attach nodes for each branch by clicking the "Logic" tag on the connecting edges to set up the conditions.
 
 <Info>
-    Please let us know about any bugs you find by [submitting a bug report](https://roadmap.vapi.ai/bug-reports). We also welcome feature requests and suggestions - you can [submit those here](https://roadmap.vapi.ai/feature-requests). For discussions about workflows and our product roadmap, please [join our Discord community](https://discord.com/invite/pUFNcf2WmH) to connect with our team.
+    Please let us know about any bugs you find by [submitting a bug report](https://roadmap.vapi.ai/bug-reports). We also welcome feature requests and suggestions - you can [submit those here](https://docs.vapi.ai/whats-new). For discussions about workflows and our product roadmap, please [join our Discord community](https://discord.com/invite/pUFNcf2WmH) to connect with our team.
 </Info>
 
 ## Nodes


### PR DESCRIPTION
## Summary
- Support page and Workflows page linked to the feature-request board at `roadmap.vapi.ai/feature-requests`. Replaced both with `https://docs.vapi.ai/whats-new`.
- Searched the whole repo for any other occurrences of this URL — none remain.

## Test plan
- [ ] Confirm `https://docs.vapi.ai/whats-new` is the intended replacement destination