### PR TITLE
docs: add DIDLogic SIP integration guide

### DIFF
--- a/fern/advanced/sip/sip-didlogic.mdx
+++ b/fern/advanced/sip/sip-didlogic.mdx
@@ -38,10 +38,10 @@ Before you begin, make sure you have:
     Save the credential and note its credential ID. You will use this ID when configuring inbound routing.
   </Step>
 
-  <Step title="Import your DIDLogic phone number">
-    Go to [Phone Numbers](https://dashboard.vapi.ai/phone-numbers), click **Create Phone Number**, and select **BYO SIP Trunk Number**.
+  <Step title="Import your DIDLogic phone number for outbound calling">
+    To place outbound calls with the SIP trunk credential, the DIDLogic phone number must be available in Vapi. Go to [Phone Numbers](https://dashboard.vapi.ai/phone-numbers). If your DIDLogic number is not already listed, click **Create Phone Number** and select **BYO SIP Trunk Number**. If the number is already listed, open it to update its configuration.
 
-    Enter your DIDLogic phone number, select the DIDLogic credential in the **SIP Trunk Credential** dropdown, and assign the assistant that should answer inbound calls. Save the phone number.
+    Enter or confirm your DIDLogic phone number and select the DIDLogic credential in the **SIP Trunk Credential** dropdown. If the number will also receive inbound calls, assign the assistant that should answer them. Save the phone number.
   </Step>
 </Steps>
 

--- a/fern/advanced/sip/sip-didlogic.mdx
+++ b/fern/advanced/sip/sip-didlogic.mdx
@@ -1,0 +1,107 @@
+---
+title: DIDLogic SIP integration
+subtitle: Connect DIDLogic SIP trunks and phone numbers to Vapi
+description: Configure DIDLogic and Vapi for inbound calls, outbound calls, and SIP REFER transfers.
+slug: advanced/sip/didlogic
+---
+
+Connect your DIDLogic SIP trunk to Vapi so your assistants can receive and place phone calls. This guide covers outbound calling through DIDLogic, inbound routing to Vapi, and optional SIP REFER transfers.
+
+For SIP trunking concepts and network requirements, see the [SIP trunking guide](/advanced/sip/sip-trunk).
+
+<Note>
+Use the Vapi dashboard, SIP hostname, and API resources for the region where your organization is hosted. This guide provides both US and EU SIP routing formats.
+</Note>
+
+## Prerequisites
+
+Before you begin, make sure you have:
+
+- An active [DIDLogic account](https://didlogic.com/get-started?utm_source=vapi_docs) with a positive balance
+- At least one purchased phone number in the DIDLogic customer portal
+- An active DIDLogic SIP account
+- A Vapi account and assistant
+
+## Configure outbound calling
+
+<Steps>
+  <Step title="Create a DIDLogic SIP trunk credential">
+    In the [Vapi dashboard](https://dashboard.vapi.ai), select your organization name, then go to **Settings → Integrations → SIP Trunk** and click **Configure New SIP Trunk**.
+
+    Configure the credential with your DIDLogic SIP account details:
+
+    - **Name:** A descriptive name, such as `DIDLogic`
+    - **IP Address / Domain:** A [DIDLogic regional SIP gateway](https://docs.didlogic.com/docs/guides/getting-started/outbound-calling#our-sip-gateways), such as `sip.nl.didlogic.net`
+    - **Username:** Your five-digit DIDLogic SIP username
+    - **Password:** Your DIDLogic SIP password
+
+    Save the credential and note its credential ID. You will use this ID when configuring inbound routing.
+  </Step>
+
+  <Step title="Import your DIDLogic phone number">
+    Go to [Phone Numbers](https://dashboard.vapi.ai/phone-numbers), click **Create Phone Number**, and select **BYO SIP Trunk Number**.
+
+    Enter your DIDLogic phone number, select the DIDLogic credential in the **SIP Trunk Credential** dropdown, and assign the assistant that should answer inbound calls. Save the phone number.
+  </Step>
+</Steps>
+
+## Configure inbound call routing
+
+<Steps>
+  <Step title="Open the DIDLogic destination settings">
+    Sign in to the [DIDLogic customer portal](https://app.didlogic.com), go to **Purchased**, find the phone number you imported into Vapi, and click **Edit** in the **Destination** section.
+  </Step>
+
+  <Step title="Route the number to Vapi">
+    Set **Destination Type** to **SIP URI**, then enter the URI for your Vapi region:
+
+    ```text
+    # US organization
+    YOUR_PHONE_NUMBER@YOUR_CREDENTIAL_ID.sip.vapi.ai
+
+    # EU organization
+    YOUR_PHONE_NUMBER@YOUR_CREDENTIAL_ID.sip.eu.vapi.ai
+    ```
+
+    Replace `YOUR_PHONE_NUMBER` with the DIDLogic number you imported and `YOUR_CREDENTIAL_ID` with the Vapi SIP trunk credential ID. Do not use a Vapi private API key in the SIP URI.
+
+    Click **Add** to save the destination.
+  </Step>
+</Steps>
+
+## Test the integration
+
+### Test outbound calling
+
+1. In Vapi, select an assistant and the imported DIDLogic phone number.
+2. Place a test call to a phone you can answer.
+3. Verify that the call connects and displays the expected caller ID.
+
+### Test inbound calling
+
+1. Dial your DIDLogic phone number from an external phone.
+2. Verify that Vapi receives the call and the assistant assigned to the number answers.
+
+## Configure SIP REFER transfers
+
+To transfer an active call through DIDLogic, ask your DIDLogic account manager to enable SIP REFER for your account.
+
+<Warning>
+DIDLogic may restrict SIP REFER transfers to other DIDLogic numbers. Confirm the supported destinations and required routing with your DIDLogic account manager.
+</Warning>
+
+<Steps>
+  <Step title="Create a transfer tool">
+    In Vapi, go to **Tools → Create Tool → Transfer Call**. Add a **SIP** destination and enter a URI in the following format:
+
+    ```text
+    sip:+E164_NUMBER@YOUR_DIDLOGIC_GATEWAY
+    ```
+
+    For example, `sip:+31203691111@sip.nl.didlogic.net`.
+  </Step>
+
+  <Step title="Configure and assign the tool">
+    Add a customer message and destination description, keep **Blind Transfer** selected so the transfer uses SIP REFER, and save the tool. Add the transfer tool to your assistant and publish the assistant.
+  </Step>
+</Steps>

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -352,6 +352,8 @@ navigation:
                     path: advanced/sip/sip-telnyx.mdx
                   - page: DIDWW
                     path: advanced/sip/sip-didww.mdx
+                  - page: DIDLogic
+                    path: advanced/sip/sip-didlogic.mdx
                   - page: Zadarma
                     path: advanced/sip/sip-zadarma.mdx
                   - page: Plivo


### PR DESCRIPTION
## Summary

- Carries forward and updates #1126 on the latest `main`
- Adds DIDLogic to the SIP provider navigation in `fern/docs.yml`
- Documents outbound calling, inbound routing, and SIP REFER transfers
- Uses regional Vapi SIP routing and the SIP trunk credential ID rather than a private API key

## Why

PR #1126 was opened from a contributor's default branch and needed navigation and technical corrections. This replacement preserves and credits that contribution without rewriting the contributor's `main` branch.

## Validation

- `git diff --check`
- `fern/docs.yml` YAML parse
- Navigation path and guide references verified

The Fern CLI produced no diagnostics but did not exit after waiting, so it was stopped and is not counted as a completed validation.

Supersedes #1126. Original contribution by @simon-didlogic.
