### PR TITLE
What's New for the week of 08-10-2026

### DIFF
--- a/fern/changelog/2026-08-10.mdx
+++ b/fern/changelog/2026-08-10.mdx
@@ -1,0 +1,9 @@
+# What's New: Week of August 10, 2026
+
+1. **Simulations**: You can now build [simulation](/observability/simulations-overview) suites and run them against your assistants or squads to test and evaluate their behavior, with detailed results for each run.
+
+2. **Unified Provider and Model Picker**: The assistant editor now combines provider and model into a single picker for your LLM, voice, and transcriber.
+
+3. **Chat and Session Log Export**: You can now export selected rows from chat and session logs and use a bulk-actions bar, matching the call logs experience.
+
+4. **SIP Transfer Improvements**: Blind [call transfers](/call-forwarding) now support a configurable `fallbackPlan`, SIP verb, and dial timeout, and cold-transfer outcomes now appear in call logs.


### PR DESCRIPTION
What's New entry for the week of August 10, 2026.

- Simulations
- Unified Provider and Model Picker
- Chat and Session Log Export
- SIP Transfer Improvements