### PR TITLE
Added a section on Dictionary fallback routing

### DIFF
--- a/fern/assistants/pronunciation-dictionaries.mdx
+++ b/fern/assistants/pronunciation-dictionaries.mdx
@@ -12,11 +12,20 @@ Pronunciation dictionaries are supported by the following voice providers:
 
 - **ElevenLabs** — phoneme rules (IPA and CMU Arpabet) and alias rules
 - **Cartesia** — "sounds-like" aliases and IPA notation (sonic-3 model only)
-- **Vapi built-in voices** — pronunciation dictionaries via a unified locator (v1 voices only)
+- **Vapi built-in voices** — pronunciation dictionaries via a unified locator
 
-<Note>
-  Pronunciation dictionaries are supported on **Vapi v1 voices** only. Vapi **v2** voices are powered by xAI's Grok model, which doesn't support pronunciation dictionaries yet. For v2 voices, use [speech tags](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech#speech-tags) to control pronunciation and delivery inline in your text instead.
-</Note>
+## Dictionary routing
+
+Adding a pronunciation dictionary to a Vapi Voice can change its underlying text-to-speech provider. For example, adding a Cartesia dictionary to a supported Vapi Voice v2 configuration routes the voice through Cartesia Sonic 3.5, with xAI as a fallback.
+
+Voice markup is provider-specific. xAI uses [speech tags](https://docs.x.ai/developers/model-capabilities/audio/text-to-speech#speech-tags), while Cartesia uses [SSML-like tags](https://docs.cartesia.ai/build-with-cartesia/capability-guides/ssml-tags). Vapi does not translate markup between providers, so a tag supported by one provider might be spoken aloud by another instead of being applied.
+
+Choose your pacing approach based on whether portability or precise timing matters more:
+
+- **For pacing across providers**, use commas, semicolons, and periods. These produce more consistent pacing across TTS providers than provider-specific markup.
+- **For precise timing**, use markup supported by the active primary provider. For example, a supported Vapi Voice v2 configuration with a Cartesia dictionary routes through Cartesia, so use Cartesia [`<break>` tags](https://docs.cartesia.ai/build-with-cartesia/capability-guides/ssml-tags#pauses-and-breaks).
+
+Test prompt formatting after adding or removing a pronunciation dictionary. If you use provider-specific markup, also test the fallback route; the xAI fallback might not interpret Cartesia markup as intended.
 
 ## How Pronunciation Dictionaries Work
 


### PR DESCRIPTION
## Description

- Added a section on Dictionary fallback routing
  
## Testing Steps

- [X ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ X] Ensure that the changed pages and code snippets work
