### PR TITLE
Add Composer improvements to What's New (week of 08-10-2026)

### DIFF
--- a/fern/changelog/2026-08-10.mdx
+++ b/fern/changelog/2026-08-10.mdx
@@ -2,8 +2,13 @@
 
 1. **Simulations**: You can now build [simulation](/observability/simulations-overview) suites and run them against your assistants or squads to test and evaluate their behavior, with detailed results for each run.
 
-2. **Unified Provider and Model Picker**: The assistant editor now combines provider and model into a single picker for your LLM, voice, and transcriber.
+2. **Composer Improvements**: [Composer](/composer) is now more capable, reliable, and easier to use when building voice agents.
+    - Upload files for it to reference, read current Vapi documentation directly, and follow new Vapi-built skills for building assistants, choosing models, managing tools, configuring phone numbers, and debugging calls.
+    - Longer, multi-step tasks are far more reliable, with mid-task error recovery and progress that survives page refreshes and thread switches.
+    - Connect Google Calendar from the conversation, clickable resource mentions with copyable IDs, and cleaner, collapsible activity timelines.
 
-3. **Chat and Session Log Export**: You can now export selected rows from chat and session logs and use a bulk-actions bar, matching the call logs experience.
+3. **Unified Provider and Model Picker**: The assistant editor now combines provider and model into a single picker for your LLM, voice, and transcriber.
 
-4. **SIP Transfer Improvements**: Blind [call transfers](/call-forwarding) now support a configurable `fallbackPlan`, SIP verb, and dial timeout, and cold-transfer outcomes now appear in call logs.
+4. **Chat and Session Log Export**: You can now export selected rows from chat and session logs and use a bulk-actions bar, matching the call logs experience.
+
+5. **SIP Transfer Improvements**: Blind [call transfers](/call-forwarding) now support a configurable `fallbackPlan`, SIP verb, and dial timeout, and cold-transfer outcomes now appear in call logs.

--- a/fern/changelog/2026-08-10.mdx
+++ b/fern/changelog/2026-08-10.mdx
@@ -2,13 +2,13 @@
 
 1. **Simulations**: You can now build [simulation](/observability/simulations-overview) suites and run them against your assistants or squads to test and evaluate their behavior, with detailed results for each run.
 
-2. **Composer Improvements**: [Composer](/composer) is now more capable, reliable, and easier to use when building voice agents.
+2. **Unified Provider and Model Picker**: The assistant editor now combines provider and model into a single picker for your LLM, voice, and transcriber.
+
+3. **Chat and Session Log Export**: You can now export selected rows from chat and session logs and use a bulk-actions bar, matching the call logs experience.
+
+4. **SIP Transfer Improvements**: Blind [call transfers](/call-forwarding) now support a configurable `fallbackPlan`, SIP verb, and dial timeout, and cold-transfer outcomes now appear in call logs.
+
+5. **Composer Improvements**: [Composer](/composer) is now more capable, reliable, and easier to use when building voice agents.
     - Upload files for it to reference, read current Vapi documentation directly, and follow new Vapi-built skills for building assistants, choosing models, managing tools, configuring phone numbers, and debugging calls.
     - Longer, multi-step tasks are far more reliable, with mid-task error recovery and progress that survives page refreshes and thread switches.
     - Connect Google Calendar from the conversation, clickable resource mentions with copyable IDs, and cleaner, collapsible activity timelines.
-
-3. **Unified Provider and Model Picker**: The assistant editor now combines provider and model into a single picker for your LLM, voice, and transcriber.
-
-4. **Chat and Session Log Export**: You can now export selected rows from chat and session logs and use a bulk-actions bar, matching the call logs experience.
-
-5. **SIP Transfer Improvements**: Blind [call transfers](/call-forwarding) now support a configurable `fallbackPlan`, SIP verb, and dial timeout, and cold-transfer outcomes now appear in call logs.


### PR DESCRIPTION
Adds a Composer improvements item to the week of August 10, 2026 entry (follow-up to #1138, which merged before this item was ready).