### PR TITLE
docs(call-forwarding): document callerId on transferred calls

### DIFF
--- a/fern/call-forwarding.mdx
+++ b/fern/call-forwarding.mdx
@@ -168,6 +168,33 @@ Customize the messages for each destination to provide clear information to the 
 }
 ```
 
+### 5. Setting the Caller ID on Transferred Calls
+
+By default, the recipient of a transferred call sees Vapi's outbound number, not the number of the person who originally called your assistant. To control what caller ID the recipient sees, add a `callerId` field to the `number` destination.
+
+To make the transfer show the original caller instead of your agent's number, pass the caller's number through:
+
+```json
+"destinations": [
+  {
+    "type": "number",
+    "number": "+1234567890",
+    "callerId": "{{customer.number}}",
+    "message": "I am forwarding your call. Please stay on the line."
+  }
+]
+```
+
+The `callerId` field accepts:
+
+- `{{customer.number}}` — the number of the person currently on the call (use this to show the original caller's ID to the recipient).
+- `{{phoneNumber.number}}` — your Vapi phone number.
+- A static number in E.164 format, such as `+1987654321`.
+
+<Note>
+`callerId` applies to `number` destinations. Whether a custom caller ID is actually displayed depends on your telephony provider and the downstream carrier — some providers only honor caller IDs that belong to numbers you own or have verified on the account. If the recipient still sees the agent's number after setting `callerId`, confirm custom caller ID is permitted on your provider/trunk.
+</Note>
+
 ## Instructing the Assistant
 
 Use the system prompt to guide the assistant on when to utilize each forwarding number. For example:


### PR DESCRIPTION
## What changed

Adds a new section **"5. Setting the Caller ID on Transferred Calls"** to `fern/call-forwarding.mdx`, documenting the `callerId` field on a `number` transfer destination:

- `{{customer.number}}` to show the original caller's number to the recipient
- `{{phoneNumber.number}}` to show your Vapi number
- a static E.164 number
- a caveat that whether a custom caller ID is honored depends on the telephony provider/carrier

## Why (gap type: incomplete content)

The Call Forwarding page is the canonical `transferCall` guide, but it documents `number` destinations, `extension`, messages, and every warm-transfer mode **without ever mentioning `callerId`**. Neither the Call Forwarding page nor Dynamic Call Transfers explains how to control the caller ID on the transferred leg.

This is a recurring customer confusion point. Call-transfer configuration is the top concrete feature topic in the last 7 days of Vapi customer feedback (support tickets, Discord, Ask AI, NPS), and it is persistent across the trailing 4 weeks — not a one-off spike. Within it, multiple distinct customers this week asked, in their own words, how to make a transferred call display the original caller's number instead of the agent's/Vapi number (e.g. "how to configure call transfers so the transferred call shows the customer's caller ID instead of the agent's phone number" and questions about caller ID for blind and live-call-control transfers). These are how-to/configuration questions with a documented answer that simply isn't on the transfer page.

`callerId` is a real, supported field — it already appears in other Vapi docs (`fern/server-url/events.mdx`, `fern/phone-numbers/phone-number-hooks.mdx`, `fern/assistants/assistant-hooks.mdx`) with the same syntax used here. This PR just surfaces it where customers actually look.

## Notes for reviewers

- Single-file, additive change; no existing content was modified.
- Please confirm the provider/carrier caveat wording matches how Vapi wants to describe custom-caller-ID support (it is intentionally conservative).