### PR TITLE
docs(calls): clarify vapifault-worker-not-available vs status.vapi.ai and billing

### DIFF
--- a/fern/calls/troubleshoot-call-errors.mdx
+++ b/fern/calls/troubleshoot-call-errors.mdx
@@ -93,11 +93,15 @@ This guide explains errors by symptom. For a complete reference of every `endedR
     | Error code | Meaning | Fix |
     |---|---|---|
     | `call.in-progress.error-vapifault-transport-never-connected` | Transport never connected | Retry. Contact [support](/support) if persistent. |
-    | `call.in-progress.error-vapifault-worker-not-available` | No call worker available | Retry. This is a transient capacity issue. |
+    | `call.in-progress.error-vapifault-worker-not-available` | No call worker available | Retry — this is almost always a brief, transient capacity blip. It can affect a specific region or a subset of orgs for a few minutes without crossing the threshold to be posted as an incident, so [status.vapi.ai](https://status.vapi.ai/) showing "operational" does not rule this out. |
     | `call.start.error-vapifault-database-error` | Internal database error | Retry. Contact [support](/support) if persistent. |
     | `call.start.error-get-org` | Error fetching organization | Verify your API key is correct |
   </Accordion>
 </AccordionGroup>
+
+<Note>
+Seeing several `vapifault-worker-not-available` (or other `vapifault`-prefixed) failures in a short window, but no matching incident on [status.vapi.ai](https://status.vapi.ai/)? Short capacity blips can resolve before they cross Vapi's incident-reporting threshold, so the status page won't always show them. Retry first — most clear up within seconds. If the errors continue for more than a few minutes or span multiple calls, contact [support](/support) with the affected `call_id` values and the exact timestamps. These errors are not billed by default; if you were charged for a call that failed with a `vapifault` error, include the `call_id` so support can issue a credit.
+</Note>
 
 ## Phone rang but nobody answered
 
@@ -243,7 +247,7 @@ To prevent provider outages from killing your calls, configure fallback provider
 
 For response-class guidance and checks across Vapi, your SIP provider, and your SIP infrastructure, see [Troubleshoot SIP response codes](/advanced/sip/troubleshoot-sip-response-codes).
 
-For a detailed transfer debugging walkthrough, see [Debug forwarding drops](/calls/troubleshoot-call-forwarding-drops).
+For a detailed transfer debugging walkthrough, see [Debug forwarding drops](/phone-calling/in-call-control/transfer-calls/debug-forwarding-drops).
 
 ## Call ended normally
 
@@ -253,7 +257,7 @@ These are not errors — they indicate the call ended as expected.
 |---|---|---|
 | `assistant-ended-call` | Assistant ended the call via a tool or function | Expected behavior |
 | `assistant-ended-call-after-message-spoken` | Assistant spoke its final message and ended | Expected behavior |
-| `assistant-ended-call-with-hangup-task` | Assistant used a hangup workflow node | Expected behavior |
+| `assistant-ended-call-with-hangup-task` | Assistant used a hangup task | Expected behavior |
 | `assistant-said-end-call-phrase` | Assistant said a configured end-call phrase | Check your end-call phrases if calls end too early |
 | `assistant-forwarded-call` | Assistant transferred the call | Expected behavior |
 | `customer-ended-call` | Customer hung up | Expected behavior |
@@ -267,7 +271,7 @@ These are not errors — they indicate the call ended as expected.
 
 - **[Call end reasons](/calls/call-ended-reason):** Complete reference of every `endedReason` code.
 - **[Debugging voice agents](/debugging):** General debugging workflow using dashboard tools, logs, and test suites.
-- **[Debug forwarding drops](/calls/troubleshoot-call-forwarding-drops):** Deep dive into transfer failures.
+- **[Debug forwarding drops](/phone-calling/in-call-control/transfer-calls/debug-forwarding-drops):** Deep dive into transfer failures.
 - **[Troubleshoot SIP trunk errors](/advanced/sip/troubleshoot-sip-trunk-credential-errors):** Resolve SIP credential validation failures.
 - **[Troubleshoot SIP response codes](/advanced/sip/troubleshoot-sip-response-codes):** Identify where a SIP request failed and what to check next.
 - **[How to report issues](/issue-reporting):** Include your `call_id` and account email when contacting support.


### PR DESCRIPTION
## What changed

In `fern/calls/troubleshoot-call-errors.mdx`, under **Phone never rang → Infrastructure errors**:

- Expanded the `Fix` guidance for `call.in-progress.error-vapifault-worker-not-available` to note that this is a brief, transient capacity blip that can affect a region or a subset of orgs without crossing the threshold to be posted as a [status.vapi.ai](https://status.vapi.ai/) incident.
- Added a `<Note>` directly after the Infrastructure errors accordion covering: what to do if `vapifault`-prefixed errors recur with no matching status page incident (retry, then contact support with `call_id`s and timestamps if it persists), and a billing clarification (these errors are not billed by default; contact support with the `call_id` for a credit if you were charged).

No other content, wording, or structure in the file was changed.