### PR TITLE
docs: tighten the Gandr custom-voice page wording

### DIFF
--- a/fern/customization/custom-voices/gandr.mdx
+++ b/fern/customization/custom-voices/gandr.mdx
@@ -5,9 +5,9 @@ description: Wire Gandr, a text to speech API for voice agents, into Vapi with t
 slug: customization/custom-voices/gandr
 ---
 
-Gandr is a text to speech API built for voice agents. It reads numbers, dates, order IDs and addresses correctly, one engine speaks 23 languages with six voices, and every render carries an inaudible watermark. Audio streams back as it is generated.
+Gandr is a text to speech API built for voice agents. It reads numbers, order IDs and addresses correctly, one engine speaks 23 languages with six voices, and every render carries an inaudible watermark. Audio streams back as it is generated.
 
-Gandr's `/v1/vapi` endpoint implements the custom-voice contract described in the [Custom TTS guide](/customization/custom-voices/custom-tts): it reads the nested `message` envelope, honours the requested `sampleRate` (8000, 16000, 22050, 24000 or 44100), and returns raw 16-bit little-endian mono PCM.
+Gandr's `/v1/vapi` endpoint implements the custom-voice contract described in the [Custom TTS guide](/customization/custom-voices/custom-tts): it reads the nested `message` envelope, honours the requested `sampleRate` (8000, 16000, 22050, 24000 or 44100), and returns raw 16-bit little-endian mono PCM. To run the TTS hop on a server you control instead, deploy the small adapter at [github.com/Gandr-AI/gandr-vapi](https://github.com/Gandr-AI/gandr-vapi); it calls Gandr's OpenAI-compatible speech endpoint and implements this same contract.
 
 <Note>A Gandr account and API key are required.</Note>
 


### PR DESCRIPTION
Small follow-up to #1136, the Gandr custom-voice guide:

- trim the readback sentence to numbers, order IDs and addresses
- link the deployable adapter, https://github.com/Gandr-AI/gandr-vapi, for users who prefer to run the TTS hop on their own server

No contract or endpoint changes. File touched: fern/customization/custom-voices/gandr.mdx.

Disclosure: I work on Gandr.