### PR TITLE
docs(tools): add OAuth Connect popup troubleshooting to Google Calendar/Sheets

### DIFF
--- a/fern/tools/google-calendar.mdx
+++ b/fern/tools/google-calendar.mdx
@@ -80,6 +80,35 @@ Now, add your chosen calendar tool(s) to your assistant:
   />
 </Frame>
 
+## Troubleshooting
+
+### Connect button doesn't open the Google authorization popup
+
+Some users report that clicking **Connect** on the Google Calendar integration closes the dialog or returns them to the Integrations page without ever showing the Google OAuth window. If you later create a calendar tool anyway, it may fail with an error like `Missing Nango configuration for tool type: google.calendar.availability.check`.
+
+This is most often caused by the browser blocking a script required to open the Google authorization popup, rather than a Vapi account issue. Work through this checklist in order:
+
+1. **Check the browser console** (F12 or right-click → Inspect → Console) for a Content Security Policy (CSP) error mentioning `nango.dev` (for example, `connect.nango.dev` or `api.nango.dev`). This confirms the popup script was blocked rather than silently failing.
+2. **Allow pop-ups** for `dashboard.vapi.ai` in your browser settings.
+3. **Disable ad blockers and privacy/script-blocking extensions** for `dashboard.vapi.ai`, then reload the page and try Connect again.
+4. **Allow third-party cookies** for `dashboard.vapi.ai`, since the OAuth flow depends on them.
+5. **Try an Incognito/private window or a different browser** to rule out a cached extension or profile setting.
+6. **On a managed or corporate network**, ask your network/IT team to allow `*.nango.dev`, since some corporate proxies and firewalls block it by default.
+
+<Note>
+  If you already have a working Connect flow for one browser or account and a *new* one fails the same way, the checklist above still applies — mismatched extension or network settings are the most common cause of this symptom across otherwise-identical setups.
+</Note>
+
+If the checklist doesn't resolve it, contact [support@vapi.ai](mailto:support@vapi.ai) or ask in the [Discord `#support` channel](https://discord.gg/pUFNcf2WmH) with:
+- Your browser and OS
+- The exact console error text, if any
+- Whether the issue reproduces in Incognito/private mode
+- Whether this is a first-time connection or a previously-connected account that stopped working
+
+<Info>
+  If you need calendar access tied to a specific end user or token rather than a single linked Google account for the whole assistant, or if Connect is blocked entirely on your network, you can bypass the built-in integration with a [Custom Tool](/tools/custom-tools) that calls the Google Calendar API directly using an OAuth token you manage.
+</Info>
+
 ## Tool Configurations
 
 ### Google Calendar Create Event Tool

--- a/fern/tools/google-sheets.mdx
+++ b/fern/tools/google-sheets.mdx
@@ -71,6 +71,31 @@ Now, add the Google Sheets tool to your assistant:
 4. In the tools dropdown, select the Google Sheets tool
 5. Click **Publish** to save your changes
 
+## Troubleshooting
+
+### Connect button doesn't open the Google authorization popup
+
+Some users report that clicking **Connect** on the Google Sheets integration closes the dialog or returns them to the Integrations page without ever showing the Google OAuth window, with no visible error.
+
+This is most often caused by the browser blocking a script required to open the Google authorization popup, rather than a Vapi account issue. Work through this checklist in order:
+
+1. **Check the browser console** (F12 or right-click → Inspect → Console) for a Content Security Policy (CSP) error mentioning `nango.dev` (for example, `connect.nango.dev` or `api.nango.dev`). This confirms the popup script was blocked rather than silently failing.
+2. **Allow pop-ups** for `dashboard.vapi.ai` in your browser settings.
+3. **Disable ad blockers and privacy/script-blocking extensions** for `dashboard.vapi.ai`, then reload the page and try Connect again.
+4. **Allow third-party cookies** for `dashboard.vapi.ai`, since the OAuth flow depends on them.
+5. **Try an Incognito/private window or a different browser** to rule out a cached extension or profile setting.
+6. **On a managed or corporate network**, ask your network/IT team to allow `*.nango.dev`, since some corporate proxies and firewalls block it by default.
+
+<Note>
+  If you already have a working Connect flow for one browser or account and a *new* one fails the same way, the checklist above still applies — mismatched extension or network settings are the most common cause of this symptom across otherwise-identical setups.
+</Note>
+
+If the checklist doesn't resolve it, contact [support@vapi.ai](mailto:support@vapi.ai) or ask in the [Discord `#support` channel](https://discord.gg/pUFNcf2WmH) with:
+- Your browser and OS
+- The exact console error text, if any
+- Whether the issue reproduces in Incognito/private mode
+- Whether this is a first-time connection or a previously-connected account that stopped working
+
 ## Tool Configuration
 
 ### Google Sheets Add Row Tool
@@ -135,4 +160,4 @@ Here's how the tool can be used in your assistant's configuration:
   >
     View the complete API documentation for tools
   </Card>
-</CardGroup> 
+</CardGroup>


### PR DESCRIPTION
## What changed

Added a **Troubleshooting** section to two existing integration pages:

- `fern/tools/google-calendar.mdx`
- `fern/tools/google-sheets.mdx`

Each new section covers: **"Connect button doesn't open the Google authorization popup"**, with a numbered checklist (check browser console for a Nango-related CSP error, allow pop-ups, disable ad blockers/privacy extensions, allow third-party cookies, try Incognito/another browser, allow `*.nango.dev` on managed networks), plus what to include when contacting support if it's still unresolved. The Google Calendar page also gets a short note on using a Custom Tool with a manually-supplied OAuth token as an alternative when the built-in Connect flow isn't viable.

No other content on either page was modified.