### PR TITLE
Fixed naming collision

### DIFF
--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -2041,6 +2041,10 @@ components:
       description: >-
         An entry in the call message history that records one or more tool calls
         requested during the conversation.
+    ToolCallResult:
+      properties:
+        message:
+          x-fern-type-name: ToolCallResultSpokenMessage
     ToolCallResultMessage:
       title: ToolCallResultMessage
       description: >-


### PR DESCRIPTION
## Description

- Updated the Open API specification to fix a naming collision.
  
## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
