### PR TITLE
docs: remove beta label from voicemail tool

### DIFF
--- a/fern/calls/voicemail-detection.mdx
+++ b/fern/calls/voicemail-detection.mdx
@@ -26,7 +26,7 @@ You can choose between several detection methods — but not all are created equ
 | **Google** | Very good accuracy, reliable | Slightly longer detection time than Vapi | ✅ Recommended |
 | **OpenAI** | High accuracy, flexible phrasing | Higher cost | ✅ Good option if budget allows |
 | **Twilio** (legacy) | Very fast machine beep detection | Prone to false positives | ⚠️ Use only in special cases |
-| **[Vapi Voicemail Tool](/tools/voicemail-tool)** (beta) | Assistant-driven voicemail decisions | Most cost effective, requires good prompting | ✅ Best for customization and cost efficiency |
+| **[Vapi Voicemail Tool](/tools/voicemail-tool)** | Assistant-driven voicemail decisions | Most cost effective, requires good prompting | ✅ Best for customization and cost efficiency |
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove the outdated `(beta)` label from the Vapi Voicemail Tool in the detection-options table.
- Preserve all existing table and page formatting.

## Validation

- `git diff --check`
- Confirmed the PR changes exactly one line in `fern/calls/voicemail-detection.mdx`.