### PR TITLE
Remove deprecated Cerebras llama-3.3-70b from the API reference (VAPICS-1120)

### DIFF
--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -3077,9 +3077,9 @@ components:
       properties:
         model:
           description: >-
-            The Cerebras model to use. `llama-3.3-70b` is deprecated and no
-            longer offered in the Dashboard; `llama3.1-8b` is the supported
-            model.
+            The Cerebras model used to generate assistant responses.
+            `llama-3.3-70b` is deprecated and no longer available in the
+            Dashboard.
           enum:
             - llama3.1-8b
         provider:

--- a/fern/apis/api/openapi-overrides.yml
+++ b/fern/apis/api/openapi-overrides.yml
@@ -3075,6 +3075,13 @@ components:
         including model, prompts, tools, knowledge-base access, and generation
         settings.
       properties:
+        model:
+          description: >-
+            The Cerebras model to use. `llama-3.3-70b` is deprecated and no
+            longer offered in the Dashboard; `llama3.1-8b` is the supported
+            model.
+          enum:
+            - llama3.1-8b
         provider:
           description: Routes assistant response generation through Cerebras.
     CustomLLMModel:


### PR DESCRIPTION
## Description

- `llama-3.3-70b` still appears in the API reference under `CerebrasModel.model` ([Create Assistant](https://docs.vapi.ai/api-reference/assistants/create#request.body.model.Cerebras.model)) but is deprecated and no longer offered in the Dashboard, so the reference advertises a model customers cannot select. Tracked in VAPICS-1120.
- `fern/apis/api/openapi.json` is re-synced from the live spec daily, so the change is made in `fern/apis/api/openapi-overrides.yml` instead: the existing `CerebrasModel` override gains a `model` entry that restricts the enum to `llama3.1-8b` and adds a description noting the deprecation. This keeps the rendered API reference consistent with `providers/model/cerebras`, which already lists only `llama3.1-8b`.
- Docs-only. The backend enum still accepts `llama-3.3-70b`; removing it there is a separate change in the API repo. `fern check` passes (0 errors; the 12 warnings are pre-existing tool discriminator-mapping warnings on main).

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work (Create Assistant and Update Assistant, `model` > `Cerebras` should list only `llama3.1-8b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
