### PR TITLE
docs(sip): state that Vapi SIP numbers are inbound only

### DIFF
--- a/fern/advanced/sip/sip.mdx
+++ b/fern/advanced/sip/sip.mdx
@@ -8,6 +8,12 @@ slug: advanced/sip
 
 This guide shows you how to set up and test SIP calls to your Vapi assistant using any SIP client or softphone. You'll create an assistant, assign it a SIP phone number, and make a call using a SIP URI. You can also pass template variables via SIP headers.
 
+<Warning>
+  A Vapi SIP phone number is for **inbound calls only**. Because it is created with a `sipUri` and no area code, it has no PSTN phone number of its own, so there is no number for it to place an outbound call from. Outbound calls fail immediately with `call.start.error-get-transport` and the message `Vapi Numbers Can't Dial Outbound Yet.`
+
+  To place outbound calls, [import a number from a supported provider](/phone-numbers/import-twilio) or [connect your own SIP trunk](/advanced/sip/sip-trunk). A SIP trunk is also what you need to call international destinations.
+</Warning>
+
 ## Choose your Vapi region
 
 Use the API base URL, private key, and SIP host from the same Vapi region. Do not create a SIP phone number in one region with a SIP URI from another region.

--- a/fern/advanced/sip/sip.mdx
+++ b/fern/advanced/sip/sip.mdx
@@ -9,9 +9,9 @@ slug: advanced/sip
 This guide shows you how to set up and test SIP calls to your Vapi assistant using any SIP client or softphone. You'll create an assistant, assign it a SIP phone number, and make a call using a SIP URI. You can also pass template variables via SIP headers.
 
 <Warning>
-  A Vapi SIP phone number is for **inbound calls only**. Because it is created with a `sipUri` and no area code, it has no PSTN phone number of its own, so there is no number for it to place an outbound call from. Outbound calls fail immediately with `call.start.error-get-transport` and the message `Vapi Numbers Can't Dial Outbound Yet.`
+  A Vapi SIP phone number supports **inbound calls only** because it has a `sipUri` but no public switched telephone network (PSTN) phone number for outbound calls. Outbound attempts fail with `call.start.error-get-transport` and the message `Vapi Numbers Can't Dial Outbound Yet.`
 
-  To place outbound calls, [import a number from a supported provider](/phone-numbers/import-twilio) or [connect your own SIP trunk](/advanced/sip/sip-trunk). A SIP trunk is also what you need to call international destinations.
+  To place outbound calls, [import a phone number from a supported provider](/phone-numbers/import-twilio) or [connect your own SIP trunk](/advanced/sip/sip-trunk). Use a SIP trunk for international destinations.
 </Warning>
 
 ## Choose your Vapi region


### PR DESCRIPTION
Branch pushed: https://github.com/chiranjeet-vapi/docs/tree/docs/free-vapi-sip-inbound-only
Open PR here: https://github.com/VapiAI/docs/compare/main...chiranjeet-vapi:docs/free-vapi-sip-inbound-only?expand=1

Title: docs(sip): state that Vapi SIP numbers are inbound only

---

## What

Adds a warning to the SIP introduction page saying that a Vapi SIP phone number (`provider: "vapi"` created with a `sipUri` and no area code) is inbound only and cannot place outbound calls.

## Why

A customer read the SIP introduction page, provisioned a SIP number, and tried an outbound call to a Pakistani number. It failed instantly with `call.start.error-get-transport` and `Vapi Numbers Can't Dial Outbound Yet.`, which does not explain the cause. The page documents only the inbound flow (softphone dials the `sipUri`, the assistant answers) and never states that outbound is unavailable, so there is nothing on the page that would have set the expectation.

The mechanism is that this number shape has no PSTN number to originate from. In the phone number resource it carries a `sipUri` and no `number` field at all, for example:

```
{"name":"Cherry Inbound SIP","sipUri":"sip:withcherry@sip.vapi.ai","provider":"vapi","status":"active"}
```

Checking production logs over 7 days, this shape appears on an outbound call once across the whole platform, versus hundreds of thousands of inbound rows. Numbers that do place outbound calls are either `provider: "vapi"` with a real `+1` number, or `provider: "byo-phone-number"` with a `credentialId`.

## Separate inconsistency, not changed here

While confirming the above I found the existing free-number outbound guidance contradicts itself, and I did not want to resolve it unilaterally in a docs PR. Flagging for whoever owns these pages:

- `fern/calls/call-outbound.mdx` line 15: "You cannot make outbound or international calls with a free Vapi number."
- `fern/calls/call-outbound.mdx` line 280: "Vapi free numbers have limited number of outbound calls per day. Import a number from Twilio, Vonage, or Telnyx to scale without limits."
- `fern/phone-numbers/free-telephony.mdx`: "**Outbound calling not supported.** Import a number from a supported telephony provider when you need higher-volume outbound calling."

The first says outbound is impossible, the other two imply it works but is capped. Production data matches the "works but capped and US only" reading for area-code free numbers: they place outbound calls, and every destination sampled over 7 days was `+1`. Happy to follow up with a second PR once someone confirms the intended policy.
