### PR TITLE
Document the ElevenLabs BYOK API key permission requirement

### DIFF
--- a/fern/customization/custom-voices/elevenlabs.mdx
+++ b/fern/customization/custom-voices/elevenlabs.mdx
@@ -16,9 +16,7 @@ This guide outlines the procedure for integrating your cloned voice with ElevenL
     Go to the 'Profile + Keys' section on the ElevenLabs website to get your API key.
 
     <Warning>
-      Create the key without endpoint access restrictions. ElevenLabs lets you [limit which endpoints a key can access](https://elevenlabs.io/docs/api-reference/authentication), and Vapi needs a key that can reach both the text-to-speech endpoints, to generate speech during calls, and the voices endpoints, to list, search, and sync your voices into Vapi. A key that cannot reach one of them fails when Vapi calls that endpoint, which shows up as a missing voice or a library that will not sync.
-
-      If you need to cap what the key can spend, use ElevenLabs' credit quota on the key instead of endpoint restrictions.
+      Create an API key without endpoint access restrictions. ElevenLabs lets you [limit which endpoints a key can access](https://elevenlabs.io/docs/api-reference/authentication). Vapi needs access to the text-to-speech endpoints to generate speech and the voices endpoints to list, search, and sync voices. Restricted access can prevent voices from appearing in search or syncing to the voice library. To limit spending in ElevenLabs, set an ElevenLabs credit quota on the API key instead of restricting endpoint access.
     </Warning>
   </Step>
   <Step title="Enter your API key in Vapi">
@@ -35,13 +33,13 @@ This guide outlines the procedure for integrating your cloned voice with ElevenL
 
 <AccordionGroup>
   <Accordion title="Your cloned voice does not appear when you search for it">
-    Searching for a voice reads the voice list from your ElevenLabs account with your key. If the key cannot read voices, Vapi gets nothing back and the voice does not appear in search results, even though it still exists in ElevenLabs. ElevenLabs rejects the request with:
+    Vapi uses your ElevenLabs API key to search the voice list in your account. If the key cannot read voices, the voice does not appear in Vapi search results even though it still exists in ElevenLabs. ElevenLabs returns this error:
 
-    ```
+    ```text
     The API key you used is missing the permission voices_read to execute this operation.
     ```
 
-    Generate a key without endpoint access restrictions, then save it again in [Integrations](https://dashboard.vapi.ai/settings/integrations).
+    Create an API key in ElevenLabs without endpoint access restrictions, then save it in [Integrations](https://dashboard.vapi.ai/settings/integrations).
   </Accordion>
   <Accordion title="Your voice library does not sync, or newly added voices never appear">
     Syncing the library calls your ElevenLabs account with your key. If ElevenLabs rejects the request, the sync fails and no voices are added. Confirm the key still exists in your ElevenLabs account, has not been rotated, and has no endpoint access restrictions.

--- a/fern/customization/custom-voices/elevenlabs.mdx
+++ b/fern/customization/custom-voices/elevenlabs.mdx
@@ -14,6 +14,12 @@ This guide outlines the procedure for integrating your cloned voice with ElevenL
   </Step>
   <Step title="Retrieve your API key">
     Go to the 'Profile + Keys' section on the ElevenLabs website to get your API key.
+
+    <Warning>
+      Create the key without endpoint access restrictions. ElevenLabs lets you [limit which endpoints a key can access](https://elevenlabs.io/docs/api-reference/authentication), and Vapi needs a key that can reach both the text-to-speech endpoints, to generate speech during calls, and the voices endpoints, to list, search, and sync your voices into Vapi. A key that cannot reach one of them fails when Vapi calls that endpoint, which shows up as a missing voice or a library that will not sync.
+
+      If you need to cap what the key can spend, use ElevenLabs' credit quota on the key instead of endpoint restrictions.
+    </Warning>
   </Step>
   <Step title="Enter your API key in Vapi">
     Navigate to the [Vapi Integrations section](https://dashboard.vapi.ai/settings/integrations) and input your ElevenLabs API key under the ElevenLabs section.
@@ -24,6 +30,23 @@ This guide outlines the procedure for integrating your cloned voice with ElevenL
     After syncing, you can search for your cloned voice in the "voices" tab in the assistants page, use it with your assistant.
   </Step>
 </Steps>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Your cloned voice does not appear when you search for it">
+    Searching for a voice reads the voice list from your ElevenLabs account with your key. If the key cannot read voices, Vapi gets nothing back and the voice does not appear in search results, even though it still exists in ElevenLabs. ElevenLabs rejects the request with:
+
+    ```
+    The API key you used is missing the permission voices_read to execute this operation.
+    ```
+
+    Generate a key without endpoint access restrictions, then save it again in [Integrations](https://dashboard.vapi.ai/settings/integrations).
+  </Accordion>
+  <Accordion title="Your voice library does not sync, or newly added voices never appear">
+    Syncing the library calls your ElevenLabs account with your key. If ElevenLabs rejects the request, the sync fails and no voices are added. Confirm the key still exists in your ElevenLabs account, has not been rotated, and has no endpoint access restrictions.
+  </Accordion>
+</AccordionGroup>
 
 **Video Tutorial:**
 <iframe

--- a/fern/providers/integrations.mdx
+++ b/fern/providers/integrations.mdx
@@ -19,7 +19,7 @@ When you add your own credentials for a provider, Vapi uses your account with th
 * That provider's API key or credentials, with access to every endpoint Vapi calls for that provider.
 
 <Note>
-  Some providers let you restrict an API key to a subset of their API. Vapi needs a key that can reach every endpoint it uses for that provider, so check the provider's page under [Voices](/providers/voice/overview), [Models](/providers/model/overview), or [Transcribers](/providers/transcriber/overview) for any key requirements before you create the key.
+  Some providers let you restrict API keys to specific endpoints, while others do not. When a provider supports endpoint restrictions, grant access to every endpoint Vapi uses. Check the provider's page under [Voices](/providers/voice/overview), [Models](/providers/model/overview), or [Transcribers](/providers/transcriber/overview) for provider-specific API key requirements.
 </Note>
 
 ## Steps

--- a/fern/providers/integrations.mdx
+++ b/fern/providers/integrations.mdx
@@ -16,7 +16,11 @@ When you add your own credentials for a provider, Vapi uses your account with th
 ## Prerequisites
 
 * An account with the provider you want to connect.
-* That provider's API key or credentials.
+* That provider's API key or credentials, with access to every endpoint Vapi calls for that provider.
+
+<Note>
+  Some providers let you restrict an API key to a subset of their API. Vapi needs a key that can reach every endpoint it uses for that provider, so check the provider's page under [Voices](/providers/voice/overview), [Models](/providers/model/overview), or [Transcribers](/providers/transcriber/overview) for any key requirements before you create the key.
+</Note>
 
 ## Steps
 

--- a/fern/providers/voice/elevenlabs.mdx
+++ b/fern/providers/voice/elevenlabs.mdx
@@ -9,6 +9,10 @@ ElevenLabs provides text-to-speech for Vapi voice agents.
 
 You can use ElevenLabs through Vapi's default integration, or connect your own account in [Integrations](/providers/integrations).
 
+<Note>
+  If you connect your own ElevenLabs account, the API key must not have endpoint access restrictions. See [set up a custom ElevenLabs voice](/customization/custom-voices/elevenlabs) for the requirement and the symptoms of a restricted key.
+</Note>
+
 ## Supported capability
 
 | Capability | Provider value |

--- a/fern/providers/voice/elevenlabs.mdx
+++ b/fern/providers/voice/elevenlabs.mdx
@@ -10,7 +10,7 @@ ElevenLabs provides text-to-speech for Vapi voice agents.
 You can use ElevenLabs through Vapi's default integration, or connect your own account in [Integrations](/providers/integrations).
 
 <Note>
-  If you connect your own ElevenLabs account, the API key must not have endpoint access restrictions. See [set up a custom ElevenLabs voice](/customization/custom-voices/elevenlabs) for the requirement and the symptoms of a restricted key.
+  If you connect an ElevenLabs account, use an API key without endpoint access restrictions. See [set up a custom ElevenLabs voice](/customization/custom-voices/elevenlabs) to review the requirement and troubleshoot restricted keys.
 </Note>
 
 ## Supported capability


### PR DESCRIPTION
## Description

<!-- describe the changes as bullet points -->
- Document that an ElevenLabs API key connected as an integration must not have endpoint access restrictions. Nothing on the ElevenLabs or Integrations pages said this, so the requirement was only discoverable by hitting the failure.
- `customization/custom-voices/elevenlabs`: state the requirement on the step where the key is created, and add a Troubleshooting section for the two symptoms a restricted key produces.
- `providers/voice/elevenlabs`: note the requirement where the page offers BYOK, linking to the setup guide.
- `providers/integrations`: note in Prerequisites that a provider key needs access to every endpoint Vapi calls for that provider.

### Why

A customer connected a scope-restricted ElevenLabs key. It was accepted, then voice search and voice library sync failed against it. ElevenLabs itself returned:

```
The API key you used is missing the permission voices_read to execute this operation.
```

on the voice search call, and rejected the voice library sync with a 401. From the customer's side the cloned voice simply stopped appearing in search, which reads as a missing voice rather than a credential problem. ElevenLabs documents that keys can be restricted per endpoint (https://elevenlabs.io/docs/api-reference/authentication), so this is a supported provider-side setting that our docs did not account for.

### Scope note

The pages state which endpoint groups the key must reach (text-to-speech and voices) rather than an exhaustive permission list, since `voices_read` is the only permission name ElevenLabs returned by name. If someone can confirm the full set the integration calls, the wording can be tightened to name them.

## Testing Steps

- [ ] Run the app locally using `fern docs dev` or navigate to preview deployment
- [ ] Ensure that the changed pages and code snippets work
- [ ] Confirm the three changed pages render, and that the new cross-links resolve: `/customization/custom-voices/elevenlabs`, `/providers/voice/overview`, `/providers/model/overview`, `/providers/transcriber/overview`
