### PR TITLE
docs: add Gandr to the Custom TTS section

### DIFF
--- a/fern/customization/custom-tts/gandr.mdx
+++ b/fern/customization/custom-tts/gandr.mdx
@@ -1,0 +1,55 @@
+---
+title: Gandr
+subtitle: Use Gandr text to speech as a custom voice in Vapi
+description: Connect the Gandr text to speech API to Vapi through a custom voice endpoint, hosted by Gandr or deployed on your own server.
+slug: customization/custom-tts/gandr
+---
+
+[Gandr](https://gandr.ai) is a text to speech API built for voice agents. It reads numbers, order IDs and addresses correctly, one engine speaks 23 languages with six voices, every render carries an inaudible watermark, and audio streams back as it is generated. You connect it through a [custom voice](/customization/custom-voices/custom-tts) endpoint. Gandr hosts one for you at `https://tts.gandr.ai/v1/vapi`, and there is a small adapter you can deploy yourself if you want the TTS hop on a server you control.
+
+<Note>A Gandr account and API key are required.</Note>
+
+<Steps>
+  <Step title="Choose the endpoint">
+    **Hosted:** `https://tts.gandr.ai/v1/vapi` already implements the custom voice contract. It reads the nested `message` envelope, synthesizes at the requested `message.sampleRate` (8000, 16000, 22050, 24000 or 44100) and streams raw 16-bit little-endian mono PCM back.
+
+    **Self-hosted:** deploy the adapter at [github.com/Gandr-AI/gandr-vapi](https://github.com/Gandr-AI/gandr-vapi). It calls Gandr's OpenAI-compatible speech endpoint and implements the same contract, so the assistant config is identical apart from the URL.
+  </Step>
+  <Step title="Point your assistant at it">
+    Store your Gandr key in a [custom credential](/server-url/server-authentication) so it never travels in the assistant config, then reference it:
+
+    ```json
+    {
+      "voice": {
+        "provider": "custom-voice",
+        "server": {
+          "url": "https://tts.gandr.ai/v1/vapi",
+          "credentialId": "<your-custom-credential-id>",
+          "timeoutSeconds": 10
+        }
+      }
+    }
+    ```
+
+    Start a call and your assistant speaks with a Gandr voice. The stock voices are `gandr-ava`, `gandr-dane`, `gandr-jenny`, `gandr-leo`, `gandr-lewis` and `gandr-mia`, and any of the 23 languages can be set per request, independent of the voice.
+  </Step>
+</Steps>
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| Audio plays at the wrong speed or pitch | Vapi expects mono 16-bit little-endian PCM at exactly `message.sampleRate`, with no WAV header. The hosted endpoint does this; if you run the adapter, check that it passes the requested rate through |
+| Voice or pronunciation edits don't take effect | Vapi caches custom voice audio. Set `"cachingEnabled": false` on the `voice` object while iterating |
+| The call times out | Check that the Gandr key in the custom credential is active and that the endpoint URL answers over HTTPS |
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Gandr custom voice guide" icon="book" href="/customization/custom-voices/gandr">
+    The step by step dashboard setup for the hosted endpoint.
+  </Card>
+  <Card title="Gandr API reference" icon="code" href="https://gandr.ai/docs">
+    Voices, languages, formats and the OpenAI-compatible speech endpoint.
+  </Card>
+</CardGroup>

--- a/fern/customization/custom-voices/gandr.mdx
+++ b/fern/customization/custom-voices/gandr.mdx
@@ -5,9 +5,9 @@ description: Wire Gandr, a text to speech API for voice agents, into Vapi with t
 slug: customization/custom-voices/gandr
 ---
 
-Gandr is a text to speech API built for voice agents. It reads numbers, dates, order IDs and addresses correctly, one engine speaks 23 languages with six voices, and every render carries an inaudible watermark. Audio streams back as it is generated.
+Gandr is a text to speech API built for voice agents. It reads numbers, order IDs and addresses correctly, one engine speaks 23 languages with six voices, and every render carries an inaudible watermark. Audio streams back as it is generated.
 
-Gandr's `/v1/vapi` endpoint implements the custom-voice contract described in the [Custom TTS guide](/customization/custom-voices/custom-tts): it reads the nested `message` envelope, honours the requested `sampleRate` (8000, 16000, 22050, 24000 or 44100), and returns raw 16-bit little-endian mono PCM.
+Gandr's `/v1/vapi` endpoint implements the custom-voice contract described in the [Custom TTS guide](/customization/custom-voices/custom-tts): it reads the nested `message` envelope, honours the requested `sampleRate` (8000, 16000, 22050, 24000 or 44100), and returns raw 16-bit little-endian mono PCM. To run the TTS hop on a server you control instead, deploy the small adapter at [github.com/Gandr-AI/gandr-vapi](https://github.com/Gandr-AI/gandr-vapi); it calls Gandr's OpenAI-compatible speech endpoint and implements this same contract.
 
 <Note>A Gandr account and API key are required.</Note>
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -315,6 +315,8 @@ navigation:
             contents:
               - page: Gradium
                 path: customization/custom-tts/gradium.mdx
+              - page: Gandr
+                path: customization/custom-tts/gandr.mdx
           - section: Custom LLMs
             icon: fa-light fa-brain-circuit
             contents:


### PR DESCRIPTION
Adds Gandr to the Custom TTS section, next to the existing Gradium page, so people who arrive through Custom TTS find the same integration that already lives under Custom voices (#1136). Also carries the small wording pass from #1176, closed in favour of this one so there is a single Gandr docs PR open.

- One new page: fern/customization/custom-tts/gandr.mdx, in the same shape as the Gradium Custom TTS page: the endpoint choice (Gandr's hosted `/v1/vapi` endpoint, or the deployable adapter at github.com/Gandr-AI/gandr-vapi for teams that want the TTS hop on their own server), the assistant config, troubleshooting and related links
- Registered in fern/docs.yml under Custom TTS
- Existing Custom voices page: tighter first sentence and one sentence pointing at the self-hosted adapter (the #1176 change)
- Cross-links the existing Custom voices page instead of duplicating its dashboard walkthrough
- No pricing, no provider page touched, zero Vapi engineering required

Disclosure: I work on Gandr.
